### PR TITLE
refactor Ackermann mix function for DRYness and readability

### DIFF
--- a/libs/config/include/drivetrain_config.h
+++ b/libs/config/include/drivetrain_config.h
@@ -1,6 +1,7 @@
 // drivetrain_config.h
 #ifndef DRIVETRAIN_CONFIG_H
 #define DRIVETRAIN_CONFIG_H
+#include <cmath>
 
 namespace CONFIG {
     enum Challenge {
@@ -21,12 +22,14 @@ namespace CONFIG {
         RIGHT
     };
 
-// chassis geometry
-    const float WHEEL_BASE = 0.18f; // metres
-    const float WHEEL_TRACK = 0.15f; // metres
+    // chassis geometry
+    constexpr float WHEEL_BASE = 0.18f; // metres
+    constexpr float WHEEL_TRACK = 0.15f; // metres
+    constexpr float HALF_WHEEL_TRACK = WHEEL_TRACK / 2;
 
-//steering
-    const float MAX_STEERING_ANGLE = 3.14 / 4; // radians
+    //steering
+    constexpr float MAX_STEERING_ANGLE = 3.14 / 4; // radians
+    const float STEERING_HYPOTENUSE = std::sqrt(HALF_WHEEL_TRACK * HALF_WHEEL_TRACK + WHEEL_BASE * WHEEL_BASE);
 
 //left steering servo
     static constexpr float LEFT_MIN_PULSE = 1032.0f; // usec

--- a/libs/config/include/drivetrain_config.h
+++ b/libs/config/include/drivetrain_config.h
@@ -13,9 +13,10 @@ namespace CONFIG {
         PI_NOON,
         TEMPLE_OF_DOOM
     };
-// define CURRENT_CHALLENGE in a earlier file with:
-// Challenge CURRENT_CHALLENGE = LAVA_PALAVA;
-// To set the current challenge and the drivetrain config appropriately
+
+    // define CURRENT_CHALLENGE in a earlier file with:
+    // Challenge CURRENT_CHALLENGE = LAVA_PALAVA;
+    // To set the current challenge and the drivetrain config appropriately
 
     enum Handedness {
         LEFT,
@@ -31,19 +32,19 @@ namespace CONFIG {
     constexpr float MAX_STEERING_ANGLE = 3.14 / 4; // radians
     const float STEERING_HYPOTENUSE = std::sqrt(HALF_WHEEL_TRACK * HALF_WHEEL_TRACK + WHEEL_BASE * WHEEL_BASE);
 
-//left steering servo
+    //left steering servo
     static constexpr float LEFT_MIN_PULSE = 1032.0f; // usec
     static constexpr float LEFT_MID_PULSE = 1599.0f; // usec
     static constexpr float LEFT_MAX_PULSE = 2200.0f; // usec
-    static constexpr float LEFT_MID_VALUE = 0.0f;    // radians @LEFT_MID_PULSE
-    static constexpr float LEFT_MIN_VALUE = 3.14 / 4;  // radians  @LEFT_MIN_PULSE (pi/4radians = 45degrees)
+    static constexpr float LEFT_MID_VALUE = 0.0f; // radians @LEFT_MID_PULSE
+    static constexpr float LEFT_MIN_VALUE = 3.14 / 4; // radians  @LEFT_MIN_PULSE (pi/4radians = 45degrees)
 
-//right steering servo
+    //right steering servo
     static constexpr float RIGHT_MIN_PULSE = 1221.0f; // usec
     static constexpr float RIGHT_MID_PULSE = 1670.0f; // usec
     static constexpr float RIGHT_MAX_PULSE = 2200.0f; // usec
-    static constexpr float RIGHT_MID_VALUE = 0.0f;    // radians @RIGHT_MID_PULSE
-    static constexpr float RIGHT_MIN_VALUE = 3.14 / 4;  // radians  @RIGHT_MIN_PULSE (pi/4radians = 45degrees)
+    static constexpr float RIGHT_MID_VALUE = 0.0f; // radians @RIGHT_MID_PULSE
+    static constexpr float RIGHT_MIN_VALUE = 3.14 / 4; // radians  @RIGHT_MIN_PULSE (pi/4radians = 45degrees)
 
 
     //wheels and gearing
@@ -53,7 +54,7 @@ namespace CONFIG {
     constexpr float GEARMOTOR_RATIO = 19.22f; // -to-1
 
 
-// Define WHEEL_DIAMETER and GEAR_RATIO based on CURRENT_CHALLENGE
+    // Define WHEEL_DIAMETER and GEAR_RATIO based on CURRENT_CHALLENGE
 #if CURRENT_CHALLENGE == ECO_DISASTER
     constexpr float WHEEL_DIAMETER = LARGE_WHEEL_DIAMETER;
     constexpr float GEAR_RATIO = 42.0 / 18.0 * GEARMOTOR_RATIO;
@@ -74,8 +75,8 @@ namespace CONFIG {
 #endif
 
 
-// motor properties
-// The counts per rev of the motor
+    // motor properties
+    // The counts per rev of the motor
     constexpr int CPR = 12;
     // The counts per revolution of the wheel
     // note that this is not constexpr because it depends on the gear ratio which is not constexpr
@@ -91,14 +92,14 @@ namespace CONFIG {
     constexpr float MAX_ANGULAR_ACCELERATION = 20; // rad/s^2
 
 
-// Control constants such as PID & feedforward
-// PID values
-    constexpr float VEL_KP = 3.25f;   // Velocity proportional (P) gain
-    constexpr float VEL_KI = 0.0f;    // Velocity integral (I) gain
-    constexpr float VEL_KD = 0.003f;    // Velocity derivative (D) gain
+    // Control constants such as PID & feedforward
+    // PID values
+    constexpr float VEL_KP = 3.25f; // Velocity proportional (P) gain
+    constexpr float VEL_KI = 0.0f; // Velocity integral (I) gain
+    constexpr float VEL_KD = 0.003f; // Velocity derivative (D) gain
 
-// feedforward values
-    constexpr float VEL_FF_GAIN = 1.0f;   // Velocity feedforward gain
-    constexpr float ACC_FF_GAIN = 0.0f;    // Acceleration feedforward gain
+    // feedforward values
+    constexpr float VEL_FF_GAIN = 1.0f; // Velocity feedforward gain
+    constexpr float ACC_FF_GAIN = 0.0f; // Acceleration feedforward gain
 }
 #endif // DRIVETRAIN_CONFIG_H

--- a/libs/config/include/drivetrain_config.h
+++ b/libs/config/include/drivetrain_config.h
@@ -46,17 +46,17 @@ namespace CONFIG {
     static constexpr float RIGHT_MIN_VALUE = 3.14 / 4;  // radians  @RIGHT_MIN_PULSE (pi/4radians = 45degrees)
 
 
-//wheels and gearing
-    const float LARGE_WHEEL_DIAMETER = 0.0816f; // metres valid for Lego 2902 "81.6" tyres
-    const float SMALL_WHEEL_DIAMETER = 0.0495f; // metres valid for Lego 15413 tyres
-    const float MECANUM_DIAMETER = 0.048f; // metres, valid for "48mm" mecanums
-    const float GEARMOTOR_RATIO = 19.22f;  // -to-1
+    //wheels and gearing
+    constexpr float LARGE_WHEEL_DIAMETER = 0.0816f; // metres valid for Lego 2902 "81.6" tyres
+    constexpr float SMALL_WHEEL_DIAMETER = 0.0495f; // metres valid for Lego 15413 tyres
+    constexpr float MECANUM_DIAMETER = 0.048f; // metres, valid for "48mm" mecanums
+    constexpr float GEARMOTOR_RATIO = 19.22f; // -to-1
 
 
 // Define WHEEL_DIAMETER and GEAR_RATIO based on CURRENT_CHALLENGE
 #if CURRENT_CHALLENGE == ECO_DISASTER
-    const float WHEEL_DIAMETER = LARGE_WHEEL_DIAMETER;
-    const float GEAR_RATIO = 42 / 18 * GEARMOTOR_RATIO;
+    constexpr float WHEEL_DIAMETER = LARGE_WHEEL_DIAMETER;
+    constexpr float GEAR_RATIO = 42.0 / 18.0 * GEARMOTOR_RATIO;
 #elif CURRENT_CHALLENGE == ESCAPE_ROUTE || CURRENT_CHALLENGE == MINESWEEPER || CURRENT_CHALLENGE == ZOMBIE_APOCALYPSE
     const float WHEEL_DIAMETER = SMALL_WHEEL_DIAMETER;
     const float GEAR_RATIO = GEARMOTOR_RATIO;
@@ -77,18 +77,18 @@ namespace CONFIG {
 // motor properties
 // The counts per rev of the motor
     constexpr int CPR = 12;
-// The counts per revolution of the wheel
-// note that this is not constexpr because it depends on the gear ratio which is not constexpr
-// because it depends on the value of CURRENT_CHALLENGE which is not evaluated until the preprocessing stage
-    const float COUNTS_PER_REV = CPR * GEAR_RATIO;
-// The scaling to apply to the motor's speed to match its real-world speed
+    // The counts per revolution of the wheel
+    // note that this is not constexpr because it depends on the gear ratio which is not constexpr
+    // because it depends on the value of CURRENT_CHALLENGE which is not evaluated until the preprocessing stage
+    constexpr float COUNTS_PER_REV = CPR * GEAR_RATIO;
+    // The scaling to apply to the motor's speed to match its real-world speed
     constexpr float SPEED_SCALE = 495.0f;
 
-//dynamics
-    const float MAX_VELOCITY = 1.28;              // m/s
-    const float MAX_ACCELERATION = 8;          // m/s^2
-    const float MAX_ANGULAR_VELOCITY = 17;      // rad/s
-    const float MAX_ANGULAR_ACCELERATION = 20; // rad/s^2
+    //dynamics
+    constexpr float MAX_VELOCITY = 1.28; // m/s
+    constexpr float MAX_ACCELERATION = 8; // m/s^2
+    constexpr float MAX_ANGULAR_VELOCITY = 17; // rad/s
+    constexpr float MAX_ANGULAR_ACCELERATION = 20; // rad/s^2
 
 
 // Control constants such as PID & feedforward

--- a/libs/config/include/drivetrain_config.h
+++ b/libs/config/include/drivetrain_config.h
@@ -16,6 +16,11 @@ namespace CONFIG {
 // Challenge CURRENT_CHALLENGE = LAVA_PALAVA;
 // To set the current challenge and the drivetrain config appropriately
 
+    enum Handedness {
+        LEFT,
+        RIGHT
+    };
+
 // chassis geometry
     const float WHEEL_BASE = 0.18f; // metres
     const float WHEEL_TRACK = 0.15f; // metres

--- a/libs/mixer/include/ackermann_mixer.h
+++ b/libs/mixer/include/ackermann_mixer.h
@@ -28,8 +28,6 @@ namespace MIXER {
                     float base = CONFIG::WHEEL_BASE,
                     float angle = CONFIG::MAX_STEERING_ANGLE); // constructor
 
-        [[nodiscard]] float getTurnRadius() const; //getter for turn radius
-        void setMaxSteeringAngle(float angle); //getter for turn radius
         AckermannOutput mix(float velocity, float angularVelocity) override; //mixing function
 
         [[nodiscard]] float

--- a/libs/mixer/include/ackermann_mixer.h
+++ b/libs/mixer/include/ackermann_mixer.h
@@ -9,6 +9,12 @@
 #include "mixer_strategy.h"
 
 namespace MIXER {
+
+    struct SteeringAngle {
+        float raw;
+        float constrained;
+        float slip;
+    };
     
     class AckermannMixer : public MixerStrategy {
     private:
@@ -18,13 +24,24 @@ namespace MIXER {
         float turnRadius;         // calculated turn radius from inputs, m to centreline
 
     public:
-        AckermannMixer(float track = CONFIG::WHEEL_TRACK,
+        explicit AckermannMixer(float track = CONFIG::WHEEL_TRACK,
                     float base = CONFIG::WHEEL_BASE,
                     float angle = CONFIG::MAX_STEERING_ANGLE); // constructor
 
-        float getTurnRadius() const; //getter for turn radius
+        [[nodiscard]] float getTurnRadius() const; //getter for turn radius
         void setMaxSteeringAngle(float angle); //getter for turn radius
         AckermannOutput mix(float velocity, float angularVelocity) override; //mixing function
+
+        [[nodiscard]] float
+        getFrontWheelSpeed(float angularVelocity, float wheelTurnRadius, float slipAngle,
+                           CONFIG::Handedness side) const;
+
+        [[nodiscard]] float getRearWheelSpeed(float velocity, float wheelTurnRadius, CONFIG::Handedness side) const;
+
+        [[nodiscard]] SteeringAngle
+        getWheelAngle(float wheelTurnRadius, float velocity, CONFIG::Handedness side) const;
+
+        [[nodiscard]] float constrainSteeringAngle(float angle) const;
 
     };
 } // namespace MIXER

--- a/libs/mixer/src/ackermann_mixer.cpp
+++ b/libs/mixer/src/ackermann_mixer.cpp
@@ -70,11 +70,11 @@ namespace MIXER {
                 // if we're turning and moving forwards, the speeds are asymmetrical and depend on the turn rate and velocity
 
                 // calculate the angles of the steerable wheels
-                SteeringAngle steeringAnglesLeft = getWheelAngle(leftWheelTurnRadius, velocity,
-                                                                 CONFIG::Handedness::LEFT);
+                const SteeringAngle steeringAnglesLeft = getWheelAngle(leftWheelTurnRadius, velocity,
+                                                                       CONFIG::Handedness::LEFT);
                 result.frontLeftAngle = steeringAnglesLeft.constrained;
-                SteeringAngle steeringAnglesRight = getWheelAngle(rightWheelTurnRadius,
-                                                                  velocity, CONFIG::Handedness::RIGHT);
+                const SteeringAngle steeringAnglesRight = getWheelAngle(rightWheelTurnRadius,
+                                                                        velocity, CONFIG::Handedness::RIGHT);
                 result.frontRightAngle = steeringAnglesRight.constrained;
 
                 // calculate the speeds of the front wheels

--- a/libs/mixer/src/ackermann_mixer.cpp
+++ b/libs/mixer/src/ackermann_mixer.cpp
@@ -21,7 +21,12 @@ int sign(T value) {
 }
 
 namespace MIXER {
-AckermannMixer::AckermannMixer(float track, float base, float angle) : wheelTrack(track), wheelBase(base), maxSteeringAngle(angle) {} 
+
+    AckermannMixer::AckermannMixer(float track, float base, float angle) : wheelTrack(track), wheelBase(base),
+                                                                           maxSteeringAngle(angle) {
+        // initialise the turn radius to zero
+        turnRadius = 0.0;
+    }
 
 AckermannOutput AckermannMixer::mix(float velocity, float angularVelocity){
     // function takes desired forward speed ("throttle") in mm/s and turn rate in radians/sec

--- a/libs/mixer/src/ackermann_mixer.cpp
+++ b/libs/mixer/src/ackermann_mixer.cpp
@@ -30,11 +30,8 @@ namespace MIXER {
     }
 
     AckermannOutput AckermannMixer::mix(float velocity, float angularVelocity) {
-        // function takes desired forward speed ("throttle") in mm/s and turn rate in radians/sec
+        // function takes desired forward speed ("throttle") in m/s and turn rate in radians/sec
         // and outputs individual wheel speeds in m/s and turn angle of steerable wheels in radians
-
-        printf("velocity: %.2f ", velocity);
-        printf(", yaw: %.2f ", angularVelocity);
 
         if (std::fabs(angularVelocity) > 0) {
             turnRadius = velocity / angularVelocity;
@@ -42,7 +39,7 @@ namespace MIXER {
             // Handle the case when yaw rate is close to zero to avoid division by zero
             turnRadius = std::numeric_limits<float>::infinity();
         }
-        printf(", turnRadius: %.2f ", turnRadius);
+
         AckermannOutput result{};
         if (std::isinf(turnRadius)) {
             // if the turn radius is infinite then we're not turning, so all wheels travel
@@ -98,12 +95,6 @@ namespace MIXER {
 
         }
 
-        printf(", FL Speed: %.2f ", result.frontLeftSpeed);
-        printf(", FR Speed: %.2f ", result.frontRightSpeed);
-        printf(", RL Speed: %.2f ", result.rearLeftSpeed);
-        printf(", RR Speed: %.2f ", result.rearRightSpeed);
-        printf(", FL Angle: %.2f ", result.frontLeftAngle);
-        printf("FR Angle: %.2f\n", result.frontRightAngle);
         return result;
     }
 

--- a/libs/mixer/src/ackermann_mixer.cpp
+++ b/libs/mixer/src/ackermann_mixer.cpp
@@ -158,14 +158,4 @@ namespace MIXER {
         return tmpSpeed * std::cos(slipAngle);
     }
 
-    float AckermannMixer::getTurnRadius() const {
-        //returns the current radius of turn (to the robots centreline) in mm
-        return turnRadius;
-    }
-
-    void AckermannMixer::setMaxSteeringAngle(float angle) {
-        // sets the maximum steering angle fo the steerable wheels, in radians
-        maxSteeringAngle = angle;
-    }
-
 } // namespace MIXER

--- a/libs/mixer/src/ackermann_mixer.cpp
+++ b/libs/mixer/src/ackermann_mixer.cpp
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <limits>
 #include <cstdio>
+#include <functional>
 
 /**
  * @brief Returns the sign of a value
@@ -28,77 +29,143 @@ namespace MIXER {
         turnRadius = 0.0;
     }
 
-AckermannOutput AckermannMixer::mix(float velocity, float angularVelocity){
-    // function takes desired forward speed ("throttle") in mm/s and turn rate in radians/sec
-    // and outputs individual wheel speeds in mm/sec and turn angle of steerable wheels in radians
+    AckermannOutput AckermannMixer::mix(float velocity, float angularVelocity) {
+        // function takes desired forward speed ("throttle") in mm/s and turn rate in radians/sec
+        // and outputs individual wheel speeds in mm/sec and turn angle of steerable wheels in radians
 
-    printf("velocity: %.2f ", velocity);
-    printf(", yaw: %.2f ", angularVelocity);
+        printf("velocity: %.2f ", velocity);
+        printf(", yaw: %.2f ", angularVelocity);
 
-    if (std::fabs(angularVelocity) > 0) {
-        turnRadius = velocity / angularVelocity;
-    } else {
-        // Handle the case when yaw rate is close to zero to avoid division by zero
-        turnRadius = std::numeric_limits<float>::infinity();
-    }
-    printf(", turnRadius: %.2f ", turnRadius);
-    AckermannOutput result;
-    if (std::isinf(turnRadius)) {
-        // if the turn radius is infinite then we're not turning, so all wheels travel 
-        // at the desired forwards speed and the steerable wheels point forwards
-        result.frontLeftSpeed = velocity;
-        result.frontRightSpeed = -velocity;
-        result.rearLeftSpeed = velocity;
-        result.rearRightSpeed = -velocity;
-        result.frontLeftAngle = 0;
-        result.frontRightAngle = 0;
-    } else {
-        if (velocity == 0) {
-        // if we're only turning, the speeds are symmetrical and just depends on the turn rate
-        // and the angle depends on the wheelbase and track
-            result.frontLeftSpeed = -angularVelocity * std::sqrt((wheelTrack / 2) * (wheelTrack / 2) + wheelBase * wheelBase);
-            result.frontRightSpeed = result.frontLeftSpeed;
-            result.rearLeftSpeed = -angularVelocity * wheelTrack / 2;
-            result.rearRightSpeed = result.rearLeftSpeed;
-            result.frontLeftAngle = std::atan2(wheelBase,  turnRadius - wheelTrack / 2);
-            result.frontRightAngle = std::atan2(wheelBase, turnRadius + wheelTrack / 2);
+        if (std::fabs(angularVelocity) > 0) {
+            turnRadius = velocity / angularVelocity;
         } else {
-            result.frontLeftSpeed = angularVelocity * std::sqrt((turnRadius - wheelTrack / 2) * (turnRadius - wheelTrack / 2) + wheelBase * wheelBase);
-            result.frontLeftSpeed = result.frontLeftSpeed *  sign(turnRadius - wheelTrack / 2);
-            result.frontRightSpeed = angularVelocity * std::sqrt((turnRadius + wheelTrack / 2) * (turnRadius + wheelTrack / 2) + wheelBase * wheelBase);
-            result.frontRightSpeed = -result.frontRightSpeed * sign(turnRadius + wheelTrack / 2);
-            result.rearLeftSpeed = velocity * (turnRadius - wheelTrack / 2) / turnRadius;
-            result.rearRightSpeed = -velocity * (turnRadius + wheelTrack / 2) / turnRadius;          
-            float tempFrontLeftAngle = -std::atan(wheelBase/(turnRadius - wheelTrack / 2));
-            float tempFrontRightAngle = std::atan(wheelBase/(turnRadius + wheelTrack / 2));
-            // constrain steering angles
-            result.frontLeftAngle = std::fmin(std::fmax(tempFrontLeftAngle, -maxSteeringAngle), maxSteeringAngle);
-            result.frontRightAngle = std::fmin(std::fmax(tempFrontRightAngle, -maxSteeringAngle), maxSteeringAngle);
+            // Handle the case when yaw rate is close to zero to avoid division by zero
+            turnRadius = std::numeric_limits<float>::infinity();
+        }
+        printf(", turnRadius: %.2f ", turnRadius);
+        AckermannOutput result{};
+        if (std::isinf(turnRadius)) {
+            // if the turn radius is infinite then we're not turning, so all wheels travel
+            // at the desired forwards speed and the steerable wheels point forwards
+            result.frontLeftSpeed = velocity;
+            result.frontRightSpeed = -velocity;
+            result.rearLeftSpeed = velocity;
+            result.rearRightSpeed = -velocity;
+            result.frontLeftAngle = 0;
+            result.frontRightAngle = 0;
+        } else {
+            const float halfWheelTrack = wheelTrack / 2;
 
-            // modify speeds to correct for limited steering
-            result.frontLeftSpeed = result.frontLeftSpeed * std::cos(tempFrontLeftAngle - result.frontLeftAngle);
-            result.frontRightSpeed = result.frontRightSpeed * std::cos(tempFrontRightAngle - result.frontRightAngle);
+            // calculate the x component of the turn radius of each wheel
+            // where x is left/right and y is direction of travel
+            const float leftWheelTurnRadius = turnRadius - halfWheelTrack;
+            const float rightWheelTurnRadius = turnRadius + halfWheelTrack;
+
+
+            if (velocity == 0) {
+                // if we're only turning, the speeds are symmetrical and just depends on the turn rate
+                result.frontRightSpeed = result.frontLeftSpeed = -angularVelocity * std::sqrt((halfWheelTrack) * (halfWheelTrack) + wheelBase * wheelBase);
+                result.rearRightSpeed = result.rearLeftSpeed = -angularVelocity * halfWheelTrack;
+                result.frontLeftAngle = getWheelAngle(leftWheelTurnRadius, velocity, CONFIG::Handedness::LEFT).constrained;
+                result.frontRightAngle = getWheelAngle(rightWheelTurnRadius, velocity, CONFIG::Handedness::RIGHT).constrained;
+            } else {
+                // if we're turning and moving forwards, the speeds are asymmetrical and depend on the turn rate and velocity
+
+                // calculate the angles of the steerable wheels
+                SteeringAngle steeringAnglesLeft = getWheelAngle(leftWheelTurnRadius, velocity,
+                                                                 CONFIG::Handedness::LEFT);
+                result.frontLeftAngle = steeringAnglesLeft.constrained;
+                SteeringAngle steeringAnglesRight = getWheelAngle(rightWheelTurnRadius,
+                                                                  velocity, CONFIG::Handedness::RIGHT);
+                result.frontRightAngle = steeringAnglesRight.constrained;
+
+                // calculate the speeds of the front wheels
+                result.frontLeftSpeed = getFrontWheelSpeed(
+                        angularVelocity,
+                        leftWheelTurnRadius,
+                        steeringAnglesLeft.slip,
+                        CONFIG::Handedness::LEFT
+                        );
+                result.frontRightSpeed = getFrontWheelSpeed(
+                        angularVelocity,
+                        rightWheelTurnRadius,
+                        steeringAnglesRight.slip,
+                        CONFIG::Handedness::RIGHT
+                        );
+                // calculate the speeds of the rear wheels
+                result.rearLeftSpeed = getRearWheelSpeed(velocity, leftWheelTurnRadius, CONFIG::Handedness::LEFT);
+                result.rearRightSpeed = getRearWheelSpeed(velocity, rightWheelTurnRadius, CONFIG::Handedness::RIGHT);
+
+            }
+
         }
 
+        printf(", FL Speed: %.2f ", result.frontLeftSpeed);
+        printf(", FR Speed: %.2f ", result.frontRightSpeed);
+        printf(", RL Speed: %.2f ", result.rearLeftSpeed);
+        printf(", RR Speed: %.2f ", result.rearRightSpeed);
+        printf(", FL Angle: %.2f ", result.frontLeftAngle);
+        printf("FR Angle: %.2f\n", result.frontRightAngle);
+        return result;
     }
-    
-    printf(", FL Speed: %.2f ", result.frontLeftSpeed);
-    printf(", FR Speed: %.2f ", result.frontRightSpeed);
-    printf(", RL Speed: %.2f ", result.rearLeftSpeed);
-    printf(", RR Speed: %.2f ", result.rearRightSpeed);
-    printf(", FL Angle: %.2f ", result.frontLeftAngle);
-    printf("FR Angle: %.2f\n", result.frontRightAngle);
-    return result;
-}
 
-float AckermannMixer::getTurnRadius() const {
-    //returns the current radius of turn (to the robots centreline) in mm
-    return turnRadius;
-}
+    float AckermannMixer::constrainSteeringAngle(float angle) const {
+        // Clamp the value
+        return std::clamp(angle, -maxSteeringAngle, maxSteeringAngle);
+    }
 
-void AckermannMixer::setMaxSteeringAngle(float angle){
-    // sets the maximum steering angle fo the steerable wheels, in radians
-    maxSteeringAngle = angle;
-}
+    SteeringAngle
+    AckermannMixer::getWheelAngle(float wheelTurnRadius, float velocity, CONFIG::Handedness side) const {
+        SteeringAngle result{};
+
+        if (velocity == 0) {
+            // if we're stationary, the angle is calculated from the wheelbase and turn radius
+            // we'll still constrain it to the maximum steering angle, but we won't apply any slip
+            // TODO: is this correct?
+            result.raw = std::atan2(wheelBase, wheelTurnRadius);;
+            result.constrained = result.raw;
+            result.slip = 0;
+            return result;
+        }
+        // if we're moving, the angle is calculated from the wheelbase and turn radius
+
+        result.raw = std::atan(wheelBase / wheelTurnRadius);
+        if (side == CONFIG::Handedness::LEFT) {
+            result.raw = -result.raw;
+        }
+        result.constrained = constrainSteeringAngle(result.raw);
+        result.slip = result.raw - result.constrained;
+        return result;
+    }
+
+    float
+    AckermannMixer::getRearWheelSpeed(float velocity, const float wheelTurnRadius, CONFIG::Handedness side) const {
+        float tmpSpeed = velocity * wheelTurnRadius / turnRadius;
+        if (side == CONFIG::Handedness::RIGHT) {
+            tmpSpeed = -tmpSpeed;
+        }
+        return tmpSpeed;
+    }
+
+    float AckermannMixer::getFrontWheelSpeed(float angularVelocity, const float wheelTurnRadius, const float slipAngle,
+                                             CONFIG::Handedness side) const {
+        float tmpSpeed = angularVelocity * std::sqrt(wheelTurnRadius * wheelTurnRadius + wheelBase * wheelBase);
+        tmpSpeed = tmpSpeed * sign(wheelTurnRadius);
+        if (side == CONFIG::Handedness::RIGHT) {
+            tmpSpeed = -tmpSpeed;
+        }
+        // return modified speeds to correct for limited steering
+        return tmpSpeed * std::cos(slipAngle);
+    }
+
+    float AckermannMixer::getTurnRadius() const {
+        //returns the current radius of turn (to the robots centreline) in mm
+        return turnRadius;
+    }
+
+    void AckermannMixer::setMaxSteeringAngle(float angle) {
+        // sets the maximum steering angle fo the steerable wheels, in radians
+        maxSteeringAngle = angle;
+    }
 
 } // namespace MIXER

--- a/libs/mixer/src/ackermann_mixer.cpp
+++ b/libs/mixer/src/ackermann_mixer.cpp
@@ -9,9 +9,15 @@
 #include <limits>
 #include <cstdio>
 
-template <typename T>
+/**
+ * @brief Returns the sign of a value
+ * @tparam T The type of the value
+ * @param value The value to check
+ * @return 1 if the value is positive, -1 if the value is negative
+ */
+template<typename T>
 int sign(T value) {
-    return (T(0) < value) - (value < T(0));
+    return std::signbit(value) ? -1 : 1;
 }
 
 namespace MIXER {

--- a/libs/mixer/src/ackermann_mixer.cpp
+++ b/libs/mixer/src/ackermann_mixer.cpp
@@ -54,18 +54,16 @@ namespace MIXER {
             result.frontLeftAngle = 0;
             result.frontRightAngle = 0;
         } else {
-            const float halfWheelTrack = wheelTrack / 2;
-
             // calculate the x component of the turn radius of each wheel
             // where x is left/right and y is direction of travel
-            const float leftWheelTurnRadius = turnRadius - halfWheelTrack;
-            const float rightWheelTurnRadius = turnRadius + halfWheelTrack;
+            const float leftWheelTurnRadius = turnRadius - CONFIG::HALF_WHEEL_TRACK;
+            const float rightWheelTurnRadius = turnRadius + CONFIG::HALF_WHEEL_TRACK;
 
 
             if (velocity == 0) {
                 // if we're only turning, the speeds are symmetrical and just depends on the turn rate
-                result.frontRightSpeed = result.frontLeftSpeed = -angularVelocity * std::sqrt((halfWheelTrack) * (halfWheelTrack) + wheelBase * wheelBase);
-                result.rearRightSpeed = result.rearLeftSpeed = -angularVelocity * halfWheelTrack;
+                result.frontRightSpeed = result.frontLeftSpeed = -angularVelocity * CONFIG::STEERING_HYPOTENUSE;
+                result.rearRightSpeed = result.rearLeftSpeed = -angularVelocity * CONFIG::HALF_WHEEL_TRACK;
                 result.frontLeftAngle = getWheelAngle(leftWheelTurnRadius, velocity, CONFIG::Handedness::LEFT).constrained;
                 result.frontRightAngle = getWheelAngle(rightWheelTurnRadius, velocity, CONFIG::Handedness::RIGHT).constrained;
             } else {

--- a/libs/mixer/src/ackermann_mixer.cpp
+++ b/libs/mixer/src/ackermann_mixer.cpp
@@ -31,7 +31,7 @@ namespace MIXER {
 
     AckermannOutput AckermannMixer::mix(float velocity, float angularVelocity) {
         // function takes desired forward speed ("throttle") in mm/s and turn rate in radians/sec
-        // and outputs individual wheel speeds in mm/sec and turn angle of steerable wheels in radians
+        // and outputs individual wheel speeds in m/s and turn angle of steerable wheels in radians
 
         printf("velocity: %.2f ", velocity);
         printf(", yaw: %.2f ", angularVelocity);


### PR DESCRIPTION
refactor some of the logic in `Ackermann::mix` so that there is less repetition, and so that it is more readable. Also do some drive-by code improvements while I'm there (thanks clang-tidy)