### PR TITLE
#14 surface mixer output into statemanager

### DIFF
--- a/libs/state_estimator/CMakeLists.txt
+++ b/libs/state_estimator/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(state_estimator STATIC
 )
 
 target_link_libraries(state_estimator PUBLIC
+        common
         config
         motor2040
         encoder

--- a/libs/state_estimator/include/state_estimator.h
+++ b/libs/state_estimator/include/state_estimator.h
@@ -48,8 +48,13 @@ namespace STATE_ESTIMATOR {
         repeating_timer_t *timer;
         State estimatedState;
         State previousState;
+        COMMON::DriveTrainState currentDriveTrainState;
         static void timerCallback(repeating_timer_t *timer);
 
+    public:
+        void updateCurrentDriveTrainState(const COMMON::DriveTrainState& newDriveTrainState);
+
+    private:
         void setupTimer() const;
 
     };

--- a/libs/state_estimator/include/state_estimator.h
+++ b/libs/state_estimator/include/state_estimator.h
@@ -9,6 +9,7 @@
 #include "hardware/timer.h"
 #include "motor2040.hpp"
 #include "drivetrain_config.h"
+#include "types.h"
 
 using namespace motor;
 using namespace encoder;
@@ -30,10 +31,7 @@ namespace STATE_ESTIMATOR {
         float velocity;
         float heading;
         float angularVelocity;
-        float FL_wheel_speed;
-        float FR_wheel_speed;
-        float RL_wheel_speed;
-        float RR_wheel_speed;
+        COMMON::DriveTrainState driveTrainState;
     };
     class StateEstimator {
     public:

--- a/libs/state_estimator/include/state_estimator.h
+++ b/libs/state_estimator/include/state_estimator.h
@@ -50,7 +50,7 @@ namespace STATE_ESTIMATOR {
         State previousState;
         static void timerCallback(repeating_timer_t *timer);
 
-        void setupTimer();
+        void setupTimer() const;
 
     };
 

--- a/libs/state_estimator/src/state_estimator.cpp
+++ b/libs/state_estimator/src/state_estimator.cpp
@@ -65,8 +65,6 @@ namespace STATE_ESTIMATOR {
         auto captureRR = encoders.REAR_RIGHT->capture();
         
         // calculate position deltas
-        float distance_travelled;
-        float heading_change;
 
         // Calculate average wheel rotation delta for left and right sides
         float left_travel = (captureFL.radians_delta() + captureRL.radians_delta()) / 2;
@@ -76,14 +74,13 @@ namespace STATE_ESTIMATOR {
         left_travel = left_travel * CONFIG::WHEEL_DIAMETER / 2;
         right_travel = right_travel * CONFIG::WHEEL_DIAMETER / 2;
 
-        distance_travelled = (left_travel - right_travel) / 2;
-        heading_change = (left_travel + right_travel) / CONFIG::WHEEL_TRACK;
+        float distance_travelled = (left_travel - right_travel) / 2;
+        float heading_change = (left_travel + right_travel) / CONFIG::WHEEL_TRACK;
 
         //calculate new position and orientation
         //calc a temp heading halfway between old heading and new
         //assumed to be representative of heading during distance_travelled
-        float tempHeading;
-        tempHeading = estimatedState.heading + heading_change / 2;
+        float tempHeading = estimatedState.heading + heading_change / 2;
         estimatedState.x = estimatedState.x + distance_travelled * sin(tempHeading);
         estimatedState.y = estimatedState.y + distance_travelled * cos(tempHeading);
 
@@ -99,9 +96,7 @@ namespace STATE_ESTIMATOR {
         }
 
         //calculate speeds
-        float left_speed;
-        float right_speed;
-        
+
         //get wheel speeds
         estimatedState.driveTrainState.speeds.frontLeft = captureFL.radians_per_second();
         estimatedState.driveTrainState.speeds.frontRight = captureFR.radians_per_second();
@@ -109,13 +104,15 @@ namespace STATE_ESTIMATOR {
         estimatedState.driveTrainState.speeds.rearRight = captureRR.radians_per_second();
 
         // average wheel speed in radians per sed
-        left_speed = (estimatedState.driveTrainState.speeds.frontLeft + estimatedState.driveTrainState.speeds.rearLeft) / 2;
+        float left_speed = (estimatedState.driveTrainState.speeds.frontLeft + estimatedState.driveTrainState.speeds.
+                            rearLeft) / 2;
         
         // convert average wheel rotation speed to linear speed
         left_speed = left_speed * CONFIG::WHEEL_DIAMETER / 2;
 
         //repeat for right side
-        right_speed = (estimatedState.driveTrainState.speeds.frontRight + estimatedState.driveTrainState.speeds.rearRight) / 2;
+        float right_speed = (estimatedState.driveTrainState.speeds.frontRight + estimatedState.driveTrainState.speeds.
+                             rearRight) / 2;
         right_speed = right_speed * CONFIG::WHEEL_DIAMETER / 2;
 
         //calc all velocities

--- a/libs/state_estimator/src/state_estimator.cpp
+++ b/libs/state_estimator/src/state_estimator.cpp
@@ -142,6 +142,10 @@ namespace STATE_ESTIMATOR {
         }
     }
 
+    void StateEstimator::updateCurrentDriveTrainState(const COMMON::DriveTrainState& newDriveTrainState) {
+        currentDriveTrainState = newDriveTrainState;
+    }
+
     StateEstimator::~StateEstimator() {
         delete encoders.FRONT_LEFT;
         delete encoders.FRONT_RIGHT;

--- a/libs/state_estimator/src/state_estimator.cpp
+++ b/libs/state_estimator/src/state_estimator.cpp
@@ -27,10 +27,12 @@ namespace STATE_ESTIMATOR {
         estimatedState.velocity = 0.0f;
         estimatedState.heading = 0.0f;
         estimatedState.angularVelocity = 0.0f;
-        estimatedState.FL_wheel_speed = 0.0f;
-        estimatedState.FR_wheel_speed = 0.0f;
-        estimatedState.RL_wheel_speed = 0.0f;
-        estimatedState.RR_wheel_speed = 0.0f;
+        estimatedState.driveTrainState.speeds.frontLeft = 0.0f;
+        estimatedState.driveTrainState.speeds.frontRight = 0.0f;
+        estimatedState.driveTrainState.speeds.frontRight = 0.0f;
+        estimatedState.driveTrainState.speeds.rearRight = 0.0f;
+        estimatedState.driveTrainState.angles.left = 0.0f;
+        estimatedState.driveTrainState.angles.right = 0.0f;
         
         instancePtr = this;
         setupTimer();
@@ -101,19 +103,19 @@ namespace STATE_ESTIMATOR {
         float right_speed;
         
         //get wheel speeds
-        estimatedState.FL_wheel_speed = captureFL.radians_per_second();
-        estimatedState.FR_wheel_speed = captureFR.radians_per_second();
-        estimatedState.RL_wheel_speed = captureRL.radians_per_second();
-        estimatedState.RR_wheel_speed = captureRR.radians_per_second();
+        estimatedState.driveTrainState.speeds.frontLeft = captureFL.radians_per_second();
+        estimatedState.driveTrainState.speeds.frontRight = captureFR.radians_per_second();
+        estimatedState.driveTrainState.speeds.rearLeft = captureRL.radians_per_second();
+        estimatedState.driveTrainState.speeds.rearRight = captureRR.radians_per_second();
 
         // average wheel speed in radians per sed
-        left_speed = (estimatedState.FL_wheel_speed + estimatedState.RL_wheel_speed) / 2;
+        left_speed = (estimatedState.driveTrainState.speeds.frontLeft + estimatedState.driveTrainState.speeds.rearLeft) / 2;
         
         // convert average wheel rotation speed to linear speed
         left_speed = left_speed * CONFIG::WHEEL_DIAMETER / 2;
 
         //repeat for right side
-        right_speed = (estimatedState.FR_wheel_speed + estimatedState.RR_wheel_speed) / 2;
+        right_speed = (estimatedState.driveTrainState.speeds.frontRight + estimatedState.driveTrainState.speeds.rearRight) / 2;
         right_speed = right_speed * CONFIG::WHEEL_DIAMETER / 2;
 
         //calc all velocities

--- a/libs/state_estimator/src/state_estimator.cpp
+++ b/libs/state_estimator/src/state_estimator.cpp
@@ -59,10 +59,10 @@ namespace STATE_ESTIMATOR {
     void StateEstimator::estimateState() {
         
         //get current encoder state
-        auto captureFL = encoders.FRONT_LEFT->capture();
-        auto captureFR = encoders.FRONT_RIGHT->capture();
-        auto captureRL = encoders.REAR_LEFT->capture();
-        auto captureRR = encoders.REAR_RIGHT->capture();
+        const auto captureFL = encoders.FRONT_LEFT->capture();
+        const auto captureFR = encoders.FRONT_RIGHT->capture();
+        const auto captureRL = encoders.REAR_LEFT->capture();
+        const auto captureRR = encoders.REAR_RIGHT->capture();
         
         // calculate position deltas
 
@@ -74,13 +74,13 @@ namespace STATE_ESTIMATOR {
         left_travel = left_travel * CONFIG::WHEEL_DIAMETER / 2;
         right_travel = right_travel * CONFIG::WHEEL_DIAMETER / 2;
 
-        float distance_travelled = (left_travel - right_travel) / 2;
-        float heading_change = (left_travel + right_travel) / CONFIG::WHEEL_TRACK;
+        const float distance_travelled = (left_travel - right_travel) / 2;
+        const float heading_change = (left_travel + right_travel) / CONFIG::WHEEL_TRACK;
 
         //calculate new position and orientation
         //calc a temp heading halfway between old heading and new
         //assumed to be representative of heading during distance_travelled
-        float tempHeading = estimatedState.heading + heading_change / 2;
+        const float tempHeading = estimatedState.heading + heading_change / 2;
         estimatedState.x = estimatedState.x + distance_travelled * sin(tempHeading);
         estimatedState.y = estimatedState.y + distance_travelled * cos(tempHeading);
 
@@ -123,9 +123,9 @@ namespace STATE_ESTIMATOR {
 
     }
 
-    void StateEstimator::setupTimer() {
-// Example configuration (adjust as needed)
-        const uint32_t timerInterval = 50;  // Interval in milliseconds
+    void StateEstimator::setupTimer() const {
+        // Example configuration (adjust as needed)
+        constexpr uint32_t timerInterval = 50;  // Interval in milliseconds
 
         // Set up the repeating timer with the callback
         if (!add_repeating_timer_ms(timerInterval,

--- a/libs/statemanager/include/statemanager.h
+++ b/libs/statemanager/include/statemanager.h
@@ -40,7 +40,7 @@ namespace STATEMANAGER {
         // max speed factor - scale the speed of the motors down to this value
         static constexpr float SPEED_EXTENT = 1.0f;
 
-        void setSpeeds(const COMMON::DriveTrainState& motorSpeeds) const;
+        void setSpeeds(const COMMON::DriveTrainState& motorSpeeds);
     };
 
 } // StateManager

--- a/libs/statemanager/include/statemanager.h
+++ b/libs/statemanager/include/statemanager.h
@@ -30,7 +30,7 @@ namespace STATEMANAGER {
     public:
         explicit StateManager(MIXER::MixerStrategy *mixerStrategy, STATE_ESTIMATOR::StateEstimator *stateEstimator);
 
-        void requestState(STATE_ESTIMATOR::State requestedState);
+        void requestState(const STATE_ESTIMATOR::State& requestedState);
     private:
         MIXER::MixerStrategy *mixerStrategy;
         STATE_ESTIMATOR::StateEstimator *stateEstimator;
@@ -39,7 +39,7 @@ namespace STATEMANAGER {
         // max speed factor - scale the speed of the motors down to this value
         static constexpr float SPEED_EXTENT = 1.0f;
 
-        void setSpeeds(COMMON::DriveTrainState motorSpeeds) const;
+        void setSpeeds(const COMMON::DriveTrainState& motorSpeeds) const;
     };
 
 } // StateManager

--- a/libs/statemanager/include/statemanager.h
+++ b/libs/statemanager/include/statemanager.h
@@ -40,7 +40,7 @@ namespace STATEMANAGER {
         // max speed factor - scale the speed of the motors down to this value
         static constexpr float SPEED_EXTENT = 1.0f;
 
-        void setSpeeds(const COMMON::DriveTrainState& motorSpeeds);
+        void setDriveTrainState(const COMMON::DriveTrainState& motorSpeeds);
     };
 
 } // StateManager

--- a/libs/statemanager/include/statemanager.h
+++ b/libs/statemanager/include/statemanager.h
@@ -34,6 +34,7 @@ namespace STATEMANAGER {
     private:
         MIXER::MixerStrategy *mixerStrategy;
         STATE_ESTIMATOR::StateEstimator *stateEstimator;
+        COMMON::DriveTrainState currentDriveTrainState{};
         Stokers stokers{};
         SteeringServos steering_servos{};
         // max speed factor - scale the speed of the motors down to this value

--- a/libs/statemanager/src/statemanager.cpp
+++ b/libs/statemanager/src/statemanager.cpp
@@ -65,5 +65,8 @@ namespace STATEMANAGER {
 
         // save the current state
         currentDriveTrainState = motorSpeeds;
+
+        // update the state estimator with the current state
+        stateEstimator->updateCurrentDriveTrainState(motorSpeeds);
     }
 } // StateManager

--- a/libs/statemanager/src/statemanager.cpp
+++ b/libs/statemanager/src/statemanager.cpp
@@ -41,7 +41,7 @@ namespace STATEMANAGER {
         currentDriveTrainState = driveTrainState;
     }
 
-    void StateManager::setSpeeds(const COMMON::DriveTrainState& motorSpeeds) const {
+    void StateManager::setSpeeds(const COMMON::DriveTrainState& motorSpeeds) {
         stokers.FRONT_LEFT->set_speed(motorSpeeds.speeds.frontLeft);
         stokers.FRONT_RIGHT->set_speed(motorSpeeds.speeds.frontRight);
         stokers.REAR_LEFT->set_speed(motorSpeeds.speeds.rearLeft);
@@ -62,5 +62,8 @@ namespace STATEMANAGER {
         } else {
             steering_servos.right->disable();
         }
+
+        // save the current state
+        currentDriveTrainState = motorSpeeds;
     }
 } // StateManager

--- a/libs/statemanager/src/statemanager.cpp
+++ b/libs/statemanager/src/statemanager.cpp
@@ -37,11 +37,11 @@ namespace STATEMANAGER {
         //printf("Angular velocity: %f ", requestedState.angularVelocity);
         //printf("\n");
         const COMMON::DriveTrainState driveTrainState = mixerStrategy->mix(requestedState.velocity, requestedState.angularVelocity);
-        setSpeeds(driveTrainState);
+        setDriveTrainState(driveTrainState);
         currentDriveTrainState = driveTrainState;
     }
 
-    void StateManager::setSpeeds(const COMMON::DriveTrainState& motorSpeeds) {
+    void StateManager::setDriveTrainState(const COMMON::DriveTrainState& motorSpeeds) {
         stokers.FRONT_LEFT->set_speed(motorSpeeds.speeds.frontLeft);
         stokers.FRONT_RIGHT->set_speed(motorSpeeds.speeds.frontRight);
         stokers.REAR_LEFT->set_speed(motorSpeeds.speeds.rearLeft);

--- a/libs/statemanager/src/statemanager.cpp
+++ b/libs/statemanager/src/statemanager.cpp
@@ -38,6 +38,7 @@ namespace STATEMANAGER {
         //printf("\n");
         const COMMON::DriveTrainState driveTrainState = mixerStrategy->mix(requestedState.velocity, requestedState.angularVelocity);
         setSpeeds(driveTrainState);
+        currentDriveTrainState = driveTrainState;
     }
 
     void StateManager::setSpeeds(const COMMON::DriveTrainState& motorSpeeds) const {

--- a/libs/statemanager/src/statemanager.cpp
+++ b/libs/statemanager/src/statemanager.cpp
@@ -36,8 +36,8 @@ namespace STATEMANAGER {
         //printf("Velocity: %f ", requestedState.velocity);
         //printf("Angular velocity: %f ", requestedState.angularVelocity);
         //printf("\n");
-        COMMON::DriveTrainState ackermannOutput = mixerStrategy->mix(requestedState.velocity, requestedState.angularVelocity);
-        setSpeeds(ackermannOutput);
+        const COMMON::DriveTrainState driveTrainState = mixerStrategy->mix(requestedState.velocity, requestedState.angularVelocity);
+        setSpeeds(driveTrainState);
     }
 
     void StateManager::setSpeeds(const COMMON::DriveTrainState& motorSpeeds) const {

--- a/libs/statemanager/src/statemanager.cpp
+++ b/libs/statemanager/src/statemanager.cpp
@@ -31,7 +31,7 @@ namespace STATEMANAGER {
 
     }
 
-    void StateManager::requestState(STATE_ESTIMATOR::State requestedState) {
+    void StateManager::requestState(const STATE_ESTIMATOR::State& requestedState) {
         //printf("Requested state...\n");
         //printf("Velocity: %f ", requestedState.velocity);
         //printf("Angular velocity: %f ", requestedState.angularVelocity);
@@ -40,7 +40,7 @@ namespace STATEMANAGER {
         setSpeeds(ackermannOutput);
     }
 
-    void StateManager::setSpeeds(COMMON::DriveTrainState motorSpeeds) const {
+    void StateManager::setSpeeds(const COMMON::DriveTrainState& motorSpeeds) const {
         stokers.FRONT_LEFT->set_speed(motorSpeeds.speeds.frontLeft);
         stokers.FRONT_RIGHT->set_speed(motorSpeeds.speeds.frontRight);
         stokers.REAR_LEFT->set_speed(motorSpeeds.speeds.rearLeft);


### PR DESCRIPTION
when setting speeds in the `StateManager`, also save the current drive train state and update the `StateEstimator`.

Ideally, we'd have the state estimator fetch the new value on demand, but  the state manager has a pointer to the state estimator and not the other way around.