### PR TITLE
update stokers with latest estimated state

### DIFF
--- a/libs/common/CMakeLists.txt
+++ b/libs/common/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_library(common INTERFACE)
+add_library(common INTERFACE
+        include/interfaces.h)
 
 
 target_include_directories(common INTERFACE

--- a/libs/common/include/interfaces.h
+++ b/libs/common/include/interfaces.h
@@ -1,0 +1,33 @@
+//
+// Created by robbe on 06/01/2024.
+//
+
+#ifndef COMMAND_H
+#define COMMAND_H
+#include "types.h"
+
+namespace COMMON {
+
+    // Observer interface
+    class Observer {
+    protected:
+        ~Observer() = default;
+
+    public:
+        virtual void update(DriveTrainState newState) = 0;
+    };
+
+
+    // Subject interface
+    class Subject {
+    protected:
+        ~Subject() = default;
+
+    public:
+        virtual void addObserver(Observer* observer) = 0;
+        virtual void notifyObservers(DriveTrainState newState) = 0;
+    };
+
+} // COMMON
+
+#endif //COMMAND_H

--- a/libs/common/include/types.h
+++ b/libs/common/include/types.h
@@ -6,11 +6,25 @@
 #define OSOD_MOTOR_2040_TYPES_H
 
 namespace COMMON {
+    namespace MOTOR_POSITION {
+        enum MotorPosition {
+            FRONT_LEFT,
+            FRONT_RIGHT,
+            REAR_LEFT,
+            REAR_RIGHT,
+            MOTOR_POSITION_COUNT // always keep this last in the enum so that we can use it to get the number of elements
+        };
+    }
     struct MotorSpeeds {
-        float frontLeft;
-        float frontRight;
-        float rearLeft;
-        float rearRight;
+        float speeds[MOTOR_POSITION::MOTOR_POSITION_COUNT];
+
+        float& operator[](const MOTOR_POSITION::MotorPosition position) {
+            return speeds[position];
+        }
+
+        const float& operator[](const MOTOR_POSITION::MotorPosition position) const {
+            return speeds[position];
+        }
     };
 
     struct SteeringAngles {

--- a/libs/mixer/include/ackermann_strategy.h
+++ b/libs/mixer/include/ackermann_strategy.h
@@ -10,7 +10,7 @@
 #include "types.h"
 
 namespace MIXER {
-
+    using namespace COMMON;
     struct SteeringAngle {
         float raw;
         float constrained;
@@ -29,7 +29,7 @@ namespace MIXER {
                     float base = CONFIG::WHEEL_BASE,
                     float angle = CONFIG::MAX_STEERING_ANGLE); // constructor
 
-        COMMON::DriveTrainState mix(float velocity, float angularVelocity) override; //mixing function
+        DriveTrainState mix(float velocity, float angularVelocity) override; //mixing function
 
         [[nodiscard]] float
         getFrontWheelSpeed(float angularVelocity, float wheelTurnRadius, float slipAngle,

--- a/libs/mixer/include/mixer_strategy.h
+++ b/libs/mixer/include/mixer_strategy.h
@@ -8,10 +8,10 @@
 #include "types.h"
 
 namespace MIXER {
-
+    using namespace COMMON;
     class MixerStrategy {
     public:
-        virtual COMMON::DriveTrainState mix(float velocity, float angularVelocity) = 0;
+        virtual DriveTrainState mix(float velocity, float angularVelocity) = 0;
     };
 }
 

--- a/libs/mixer/include/tank_steer_strategy.h
+++ b/libs/mixer/include/tank_steer_strategy.h
@@ -13,7 +13,7 @@ namespace MIXER {
         // This class implements a steering strategy for a tank-like robot.
         // It calculates the motor speeds based on the given linear and angular velocities.
     public:
-        COMMON::DriveTrainState mix(float velocity, float angularVelocity) override;
+        DriveTrainState mix(float velocity, float angularVelocity) override;
     };
 }
 

--- a/libs/mixer/src/ackermann_strategy.cpp
+++ b/libs/mixer/src/ackermann_strategy.cpp
@@ -23,14 +23,13 @@ int sign(T value) {
 }
 
 namespace MIXER {
-
     AckermannMixer::AckermannMixer(float track, float base, float angle) : wheelTrack(track), wheelBase(base),
                                                                            maxSteeringAngle(angle) {
         // initialise the turn radius to zero
         turnRadius = 0.0;
     }
 
-    COMMON::DriveTrainState AckermannMixer::mix(float velocity, float angularVelocity) {
+    DriveTrainState AckermannMixer::mix(float velocity, float angularVelocity) {
         // function takes desired forward speed ("throttle") in m/s and turn rate in radians/sec
         // and outputs individual wheel speeds in m/s and turn angle of steerable wheels in radians
 
@@ -41,14 +40,14 @@ namespace MIXER {
             turnRadius = std::numeric_limits<float>::infinity();
         }
 
-        COMMON::DriveTrainState result{};
+        DriveTrainState result{};
         if (std::isinf(turnRadius)) {
             // if the turn radius is infinite then we're not turning, so all wheels travel
             // at the desired forwards speed and the steerable wheels point forwards
-            result.speeds[COMMON::MOTOR_POSITION::FRONT_LEFT] = velocity;
-            result.speeds[COMMON::MOTOR_POSITION::FRONT_RIGHT] = -velocity;
-            result.speeds[COMMON::MOTOR_POSITION::REAR_LEFT] = velocity;
-            result.speeds[COMMON::MOTOR_POSITION::REAR_RIGHT] = -velocity;
+            result.speeds[MOTOR_POSITION::FRONT_LEFT] = velocity;
+            result.speeds[MOTOR_POSITION::FRONT_RIGHT] = -velocity;
+            result.speeds[MOTOR_POSITION::REAR_LEFT] = velocity;
+            result.speeds[MOTOR_POSITION::REAR_RIGHT] = -velocity;
             result.angles.left = 0;
             result.angles.right = 0;
         } else {
@@ -60,8 +59,8 @@ namespace MIXER {
 
             if (velocity == 0) {
                 // if we're only turning, the speeds are symmetrical and just depends on the turn rate
-                result.speeds[COMMON::MOTOR_POSITION::FRONT_RIGHT] = result.speeds[COMMON::MOTOR_POSITION::FRONT_LEFT] = -angularVelocity * CONFIG::STEERING_HYPOTENUSE;
-                result.speeds[COMMON::MOTOR_POSITION::REAR_RIGHT] = result.speeds[COMMON::MOTOR_POSITION::REAR_LEFT] = -angularVelocity * CONFIG::HALF_WHEEL_TRACK;
+                result.speeds[MOTOR_POSITION::FRONT_RIGHT] = result.speeds[MOTOR_POSITION::FRONT_LEFT] = -angularVelocity * CONFIG::STEERING_HYPOTENUSE;
+                result.speeds[MOTOR_POSITION::REAR_RIGHT] = result.speeds[MOTOR_POSITION::REAR_LEFT] = -angularVelocity * CONFIG::HALF_WHEEL_TRACK;
                 result.angles.left = getWheelAngle(leftWheelTurnRadius, velocity, CONFIG::Handedness::LEFT).constrained;
                 result.angles.right = getWheelAngle(rightWheelTurnRadius, velocity, CONFIG::Handedness::RIGHT).constrained;
             } else {
@@ -76,21 +75,21 @@ namespace MIXER {
                 result.angles.right = steeringAnglesRight.constrained;
 
                 // calculate the speeds of the front wheels
-                result.speeds[COMMON::MOTOR_POSITION::FRONT_LEFT] = getFrontWheelSpeed(
+                result.speeds[MOTOR_POSITION::FRONT_LEFT] = getFrontWheelSpeed(
                         angularVelocity,
                         leftWheelTurnRadius,
                         steeringAnglesLeft.slip,
                         CONFIG::Handedness::LEFT
                         );
-                result.speeds[COMMON::MOTOR_POSITION::FRONT_RIGHT] = getFrontWheelSpeed(
+                result.speeds[MOTOR_POSITION::FRONT_RIGHT] = getFrontWheelSpeed(
                         angularVelocity,
                         rightWheelTurnRadius,
                         steeringAnglesRight.slip,
                         CONFIG::Handedness::RIGHT
                         );
                 // calculate the speeds of the rear wheels
-                result.speeds[COMMON::MOTOR_POSITION::REAR_LEFT] = getRearWheelSpeed(velocity, leftWheelTurnRadius, CONFIG::Handedness::LEFT);
-                result.speeds[COMMON::MOTOR_POSITION::REAR_RIGHT] = getRearWheelSpeed(velocity, rightWheelTurnRadius, CONFIG::Handedness::RIGHT);
+                result.speeds[MOTOR_POSITION::REAR_LEFT] = getRearWheelSpeed(velocity, leftWheelTurnRadius, CONFIG::Handedness::LEFT);
+                result.speeds[MOTOR_POSITION::REAR_RIGHT] = getRearWheelSpeed(velocity, rightWheelTurnRadius, CONFIG::Handedness::RIGHT);
 
             }
 

--- a/libs/mixer/src/ackermann_strategy.cpp
+++ b/libs/mixer/src/ackermann_strategy.cpp
@@ -45,10 +45,10 @@ namespace MIXER {
         if (std::isinf(turnRadius)) {
             // if the turn radius is infinite then we're not turning, so all wheels travel
             // at the desired forwards speed and the steerable wheels point forwards
-            result.speeds.frontLeft = velocity;
-            result.speeds.frontRight = -velocity;
-            result.speeds.rearLeft = velocity;
-            result.speeds.rearRight = -velocity;
+            result.speeds[COMMON::MOTOR_POSITION::FRONT_LEFT] = velocity;
+            result.speeds[COMMON::MOTOR_POSITION::FRONT_RIGHT] = -velocity;
+            result.speeds[COMMON::MOTOR_POSITION::REAR_LEFT] = velocity;
+            result.speeds[COMMON::MOTOR_POSITION::REAR_RIGHT] = -velocity;
             result.angles.left = 0;
             result.angles.right = 0;
         } else {
@@ -60,8 +60,8 @@ namespace MIXER {
 
             if (velocity == 0) {
                 // if we're only turning, the speeds are symmetrical and just depends on the turn rate
-                result.speeds.frontRight = result.speeds.frontLeft = -angularVelocity * CONFIG::STEERING_HYPOTENUSE;
-                result.speeds.rearRight = result.speeds.rearLeft = -angularVelocity * CONFIG::HALF_WHEEL_TRACK;
+                result.speeds[COMMON::MOTOR_POSITION::FRONT_RIGHT] = result.speeds[COMMON::MOTOR_POSITION::FRONT_LEFT] = -angularVelocity * CONFIG::STEERING_HYPOTENUSE;
+                result.speeds[COMMON::MOTOR_POSITION::REAR_RIGHT] = result.speeds[COMMON::MOTOR_POSITION::REAR_LEFT] = -angularVelocity * CONFIG::HALF_WHEEL_TRACK;
                 result.angles.left = getWheelAngle(leftWheelTurnRadius, velocity, CONFIG::Handedness::LEFT).constrained;
                 result.angles.right = getWheelAngle(rightWheelTurnRadius, velocity, CONFIG::Handedness::RIGHT).constrained;
             } else {
@@ -76,21 +76,21 @@ namespace MIXER {
                 result.angles.right = steeringAnglesRight.constrained;
 
                 // calculate the speeds of the front wheels
-                result.speeds.frontLeft = getFrontWheelSpeed(
+                result.speeds[COMMON::MOTOR_POSITION::FRONT_LEFT] = getFrontWheelSpeed(
                         angularVelocity,
                         leftWheelTurnRadius,
                         steeringAnglesLeft.slip,
                         CONFIG::Handedness::LEFT
                         );
-                result.speeds.frontRight = getFrontWheelSpeed(
+                result.speeds[COMMON::MOTOR_POSITION::FRONT_RIGHT] = getFrontWheelSpeed(
                         angularVelocity,
                         rightWheelTurnRadius,
                         steeringAnglesRight.slip,
                         CONFIG::Handedness::RIGHT
                         );
                 // calculate the speeds of the rear wheels
-                result.speeds.rearLeft = getRearWheelSpeed(velocity, leftWheelTurnRadius, CONFIG::Handedness::LEFT);
-                result.speeds.rearRight = getRearWheelSpeed(velocity, rightWheelTurnRadius, CONFIG::Handedness::RIGHT);
+                result.speeds[COMMON::MOTOR_POSITION::REAR_LEFT] = getRearWheelSpeed(velocity, leftWheelTurnRadius, CONFIG::Handedness::LEFT);
+                result.speeds[COMMON::MOTOR_POSITION::REAR_RIGHT] = getRearWheelSpeed(velocity, rightWheelTurnRadius, CONFIG::Handedness::RIGHT);
 
             }
 

--- a/libs/mixer/src/tank_steer_strategy.cpp
+++ b/libs/mixer/src/tank_steer_strategy.cpp
@@ -7,7 +7,7 @@
 
 using namespace MIXER;
 
-COMMON::DriveTrainState TankSteerStrategy::mix(float velocity, float angularVelocity) {
+DriveTrainState TankSteerStrategy::mix(float velocity, float angularVelocity) {
     float left = velocity - angularVelocity;
     float right = velocity + angularVelocity;
     float abs_left = left >= 0 ? left : -left;
@@ -22,12 +22,12 @@ COMMON::DriveTrainState TankSteerStrategy::mix(float velocity, float angularVelo
     float scaled_left = (left * speed_factor);
     float scaled_right = (right * speed_factor) * -1;
 
-    COMMON::DriveTrainState result = {};
+    DriveTrainState result = {};
     result.speeds = {};
-    result.speeds[COMMON::MOTOR_POSITION::FRONT_LEFT] = scaled_left;
-    result.speeds[COMMON::MOTOR_POSITION::FRONT_RIGHT] = scaled_right;
-    result.speeds[COMMON::MOTOR_POSITION::REAR_LEFT] = scaled_left;
-    result.speeds[COMMON::MOTOR_POSITION::REAR_RIGHT] = scaled_right;
+    result.speeds[MOTOR_POSITION::FRONT_LEFT] = scaled_left;
+    result.speeds[MOTOR_POSITION::FRONT_RIGHT] = scaled_right;
+    result.speeds[MOTOR_POSITION::REAR_LEFT] = scaled_left;
+    result.speeds[MOTOR_POSITION::REAR_RIGHT] = scaled_right;
     result.angles = {0, 0};
 
     return result;

--- a/libs/mixer/src/tank_steer_strategy.cpp
+++ b/libs/mixer/src/tank_steer_strategy.cpp
@@ -23,7 +23,11 @@ COMMON::DriveTrainState TankSteerStrategy::mix(float velocity, float angularVelo
     float scaled_right = (right * speed_factor) * -1;
 
     COMMON::DriveTrainState result = {};
-    result.speeds = {scaled_left, scaled_right, scaled_left, scaled_right};
+    result.speeds = {};
+    result.speeds[COMMON::MOTOR_POSITION::FRONT_LEFT] = scaled_left;
+    result.speeds[COMMON::MOTOR_POSITION::FRONT_RIGHT] = scaled_right;
+    result.speeds[COMMON::MOTOR_POSITION::REAR_LEFT] = scaled_left;
+    result.speeds[COMMON::MOTOR_POSITION::REAR_RIGHT] = scaled_right;
     result.angles = {0, 0};
 
     return result;

--- a/libs/state_estimator/include/state_estimator.h
+++ b/libs/state_estimator/include/state_estimator.h
@@ -22,7 +22,7 @@ struct Encoders {
 };
 
 namespace STATE_ESTIMATOR {
-
+    using namespace COMMON;
     // define a State struct containing the state parameters that can be requested or tracked
     struct State {
         float x;
@@ -32,9 +32,9 @@ namespace STATE_ESTIMATOR {
         float velocity;
         float heading;
         float angularVelocity;
-        COMMON::DriveTrainState driveTrainState;
+        DriveTrainState driveTrainState;
     };
-    class StateEstimator: public COMMON::Subject {
+    class StateEstimator: public Subject {
     public:
         explicit StateEstimator();
 
@@ -44,8 +44,8 @@ namespace STATE_ESTIMATOR {
         void showValues() const;
         void estimateState();
         void publishState() const;
-        void addObserver(COMMON::Observer* observer) override;
-        void notifyObservers(COMMON::DriveTrainState newState) override;
+        void addObserver(Observer* observer) override;
+        void notifyObservers(DriveTrainState newState) override;
 
     private:
         Encoders encoders;
@@ -53,15 +53,15 @@ namespace STATE_ESTIMATOR {
         repeating_timer_t *timer;
         State estimatedState;
         State previousState;
-        COMMON::DriveTrainState currentDriveTrainState;
+        DriveTrainState currentDriveTrainState;
         static void timerCallback(repeating_timer_t *timer);
 
     public:
-        void updateCurrentDriveTrainState(const COMMON::DriveTrainState& newDriveTrainState);
+        void updateCurrentDriveTrainState(const DriveTrainState& newDriveTrainState);
 
     private:
         void setupTimer() const;
-        COMMON::Observer* observers[10];
+        Observer* observers[10];
         int observerCount = 0;
 
 

--- a/libs/state_estimator/include/state_estimator.h
+++ b/libs/state_estimator/include/state_estimator.h
@@ -9,6 +9,7 @@
 #include "hardware/timer.h"
 #include "motor2040.hpp"
 #include "drivetrain_config.h"
+#include "interfaces.h"
 #include "types.h"
 
 using namespace motor;
@@ -33,14 +34,18 @@ namespace STATE_ESTIMATOR {
         float angularVelocity;
         COMMON::DriveTrainState driveTrainState;
     };
-    class StateEstimator {
+    class StateEstimator: public COMMON::Subject {
     public:
         explicit StateEstimator();
 
+    protected:
         ~StateEstimator();  // Destructor to cancel the timer
+    public:
         void showValues() const;
         void estimateState();
         void publishState() const;
+        void addObserver(COMMON::Observer* observer) override;
+        void notifyObservers(COMMON::DriveTrainState newState) override;
 
     private:
         Encoders encoders;
@@ -56,6 +61,10 @@ namespace STATE_ESTIMATOR {
 
     private:
         void setupTimer() const;
+        COMMON::Observer* observers[10];
+        int observerCount = 0;
+
+
 
     };
 

--- a/libs/state_estimator/src/state_estimator.cpp
+++ b/libs/state_estimator/src/state_estimator.cpp
@@ -27,10 +27,10 @@ namespace STATE_ESTIMATOR {
         estimatedState.velocity = 0.0f;
         estimatedState.heading = 0.0f;
         estimatedState.angularVelocity = 0.0f;
-        estimatedState.driveTrainState.speeds[COMMON::MOTOR_POSITION::FRONT_LEFT] = 0.0f;
-        estimatedState.driveTrainState.speeds[COMMON::MOTOR_POSITION::FRONT_RIGHT] = 0.0f;
-        estimatedState.driveTrainState.speeds[COMMON::MOTOR_POSITION::REAR_LEFT] = 0.0f;
-        estimatedState.driveTrainState.speeds[COMMON::MOTOR_POSITION::REAR_RIGHT] = 0.0f;
+        estimatedState.driveTrainState.speeds[MOTOR_POSITION::FRONT_LEFT] = 0.0f;
+        estimatedState.driveTrainState.speeds[MOTOR_POSITION::FRONT_RIGHT] = 0.0f;
+        estimatedState.driveTrainState.speeds[MOTOR_POSITION::REAR_LEFT] = 0.0f;
+        estimatedState.driveTrainState.speeds[MOTOR_POSITION::REAR_RIGHT] = 0.0f;
         estimatedState.driveTrainState.angles.left = 0.0f;
         estimatedState.driveTrainState.angles.right = 0.0f;
         
@@ -56,13 +56,13 @@ namespace STATE_ESTIMATOR {
         showValues();
     }
 
-    void StateEstimator::addObserver(COMMON::Observer* observer) {
+    void StateEstimator::addObserver(Observer* observer) {
         if (observerCount < 10) {
             observers[observerCount++] = observer;
         }
     }
 
-    void StateEstimator::notifyObservers(const COMMON::DriveTrainState newState) {
+    void StateEstimator::notifyObservers(const DriveTrainState newState) {
         for (int i = 0; i < observerCount; i++) {
             observers[i]->update(newState);
         }
@@ -116,22 +116,22 @@ namespace STATE_ESTIMATOR {
         //calculate speeds
 
         //get wheel speeds
-        estimatedState.driveTrainState.speeds[COMMON::MOTOR_POSITION::FRONT_LEFT] = captureFL.radians_per_second();
+        estimatedState.driveTrainState.speeds[MOTOR_POSITION::FRONT_LEFT] = captureFL.radians_per_second();
 
-        estimatedState.driveTrainState.speeds[COMMON::MOTOR_POSITION::FRONT_RIGHT] = captureFR.radians_per_second();
-        estimatedState.driveTrainState.speeds[COMMON::MOTOR_POSITION::REAR_LEFT] = captureRL.radians_per_second();
-        estimatedState.driveTrainState.speeds[COMMON::MOTOR_POSITION::REAR_RIGHT] = captureRR.radians_per_second();
+        estimatedState.driveTrainState.speeds[MOTOR_POSITION::FRONT_RIGHT] = captureFR.radians_per_second();
+        estimatedState.driveTrainState.speeds[MOTOR_POSITION::REAR_LEFT] = captureRL.radians_per_second();
+        estimatedState.driveTrainState.speeds[MOTOR_POSITION::REAR_RIGHT] = captureRR.radians_per_second();
 
         // average wheel speed in radians per side, accounting for angle of front wheels
-        float left_speed = (estimatedState.driveTrainState.speeds[COMMON::MOTOR_POSITION::FRONT_LEFT] * cos(estimatedState.driveTrainState.angles.left)
-                             + estimatedState.driveTrainState.speeds[COMMON::MOTOR_POSITION::REAR_LEFT]) / 2;
+        float left_speed = (estimatedState.driveTrainState.speeds[MOTOR_POSITION::FRONT_LEFT] * cos(estimatedState.driveTrainState.angles.left)
+                             + estimatedState.driveTrainState.speeds[MOTOR_POSITION::REAR_LEFT]) / 2;
         
         // convert average wheel rotation speed to linear speed
         left_speed = left_speed * CONFIG::WHEEL_DIAMETER / 2;
 
         //repeat for right side
-        float right_speed = (estimatedState.driveTrainState.speeds[COMMON::MOTOR_POSITION::FRONT_RIGHT] * cos(estimatedState.driveTrainState.angles.right)
-                             + estimatedState.driveTrainState.speeds[COMMON::MOTOR_POSITION::REAR_RIGHT]) / 2;
+        float right_speed = (estimatedState.driveTrainState.speeds[MOTOR_POSITION::FRONT_RIGHT] * cos(estimatedState.driveTrainState.angles.right)
+                             + estimatedState.driveTrainState.speeds[MOTOR_POSITION::REAR_RIGHT]) / 2;
         right_speed = right_speed * CONFIG::WHEEL_DIAMETER / 2;
 
         //calc all velocities
@@ -166,7 +166,7 @@ namespace STATE_ESTIMATOR {
         }
     }
 
-    void StateEstimator::updateCurrentDriveTrainState(const COMMON::DriveTrainState& newDriveTrainState) {
+    void StateEstimator::updateCurrentDriveTrainState(const DriveTrainState& newDriveTrainState) {
         currentDriveTrainState = newDriveTrainState;
     }
 

--- a/libs/state_estimator/src/state_estimator.cpp
+++ b/libs/state_estimator/src/state_estimator.cpp
@@ -27,10 +27,10 @@ namespace STATE_ESTIMATOR {
         estimatedState.velocity = 0.0f;
         estimatedState.heading = 0.0f;
         estimatedState.angularVelocity = 0.0f;
-        estimatedState.driveTrainState.speeds.frontLeft = 0.0f;
-        estimatedState.driveTrainState.speeds.frontRight = 0.0f;
-        estimatedState.driveTrainState.speeds.frontRight = 0.0f;
-        estimatedState.driveTrainState.speeds.rearRight = 0.0f;
+        estimatedState.driveTrainState.speeds[COMMON::MOTOR_POSITION::FRONT_LEFT] = 0.0f;
+        estimatedState.driveTrainState.speeds[COMMON::MOTOR_POSITION::FRONT_RIGHT] = 0.0f;
+        estimatedState.driveTrainState.speeds[COMMON::MOTOR_POSITION::REAR_LEFT] = 0.0f;
+        estimatedState.driveTrainState.speeds[COMMON::MOTOR_POSITION::REAR_RIGHT] = 0.0f;
         estimatedState.driveTrainState.angles.left = 0.0f;
         estimatedState.driveTrainState.angles.right = 0.0f;
         
@@ -104,21 +104,22 @@ namespace STATE_ESTIMATOR {
         //calculate speeds
 
         //get wheel speeds
-        estimatedState.driveTrainState.speeds.frontLeft = captureFL.radians_per_second();
-        estimatedState.driveTrainState.speeds.frontRight = captureFR.radians_per_second();
-        estimatedState.driveTrainState.speeds.rearLeft = captureRL.radians_per_second();
-        estimatedState.driveTrainState.speeds.rearRight = captureRR.radians_per_second();
+        estimatedState.driveTrainState.speeds[COMMON::MOTOR_POSITION::FRONT_LEFT] = captureFL.radians_per_second();
+
+        estimatedState.driveTrainState.speeds[COMMON::MOTOR_POSITION::FRONT_RIGHT] = captureFR.radians_per_second();
+        estimatedState.driveTrainState.speeds[COMMON::MOTOR_POSITION::REAR_LEFT] = captureRL.radians_per_second();
+        estimatedState.driveTrainState.speeds[COMMON::MOTOR_POSITION::REAR_RIGHT] = captureRR.radians_per_second();
 
         // average wheel speed in radians per side, accounting for angle of front wheels
-        float left_speed = (estimatedState.driveTrainState.speeds.frontLeft * cos(estimatedState.driveTrainState.angles.left)
-                             + estimatedState.driveTrainState.speeds.rearLeft) / 2;
+        float left_speed = (estimatedState.driveTrainState.speeds[COMMON::MOTOR_POSITION::FRONT_LEFT] * cos(estimatedState.driveTrainState.angles.left)
+                             + estimatedState.driveTrainState.speeds[COMMON::MOTOR_POSITION::REAR_LEFT]) / 2;
         
         // convert average wheel rotation speed to linear speed
         left_speed = left_speed * CONFIG::WHEEL_DIAMETER / 2;
 
         //repeat for right side
-        float right_speed = (estimatedState.driveTrainState.speeds.frontRight * cos(estimatedState.driveTrainState.angles.right)
-                             + estimatedState.driveTrainState.speeds.rearRight) / 2;
+        float right_speed = (estimatedState.driveTrainState.speeds[COMMON::MOTOR_POSITION::FRONT_RIGHT] * cos(estimatedState.driveTrainState.angles.right)
+                             + estimatedState.driveTrainState.speeds[COMMON::MOTOR_POSITION::REAR_RIGHT]) / 2;
         right_speed = right_speed * CONFIG::WHEEL_DIAMETER / 2;
 
         //calc all velocities

--- a/libs/state_estimator/src/state_estimator.cpp
+++ b/libs/state_estimator/src/state_estimator.cpp
@@ -56,6 +56,18 @@ namespace STATE_ESTIMATOR {
         showValues();
     }
 
+    void StateEstimator::addObserver(COMMON::Observer* observer) {
+        if (observerCount < 10) {
+            observers[observerCount++] = observer;
+        }
+    }
+
+    void StateEstimator::notifyObservers(const COMMON::DriveTrainState newState) {
+        for (int i = 0; i < observerCount; i++) {
+            observers[i]->update(newState);
+        }
+    }
+
     void StateEstimator::estimateState() {
         
         //get current encoder state
@@ -129,6 +141,9 @@ namespace STATE_ESTIMATOR {
 
         //now less accurate as we're taking the wrong component of the front wheel speeds. will be taken from IMU in future
         estimatedState.angularVelocity= (left_speed + right_speed) / CONFIG::WHEEL_TRACK;
+
+        // notify observers of the new state
+        notifyObservers(estimatedState.driveTrainState);
 
     }
 

--- a/libs/statemanager/include/statemanager.h
+++ b/libs/statemanager/include/statemanager.h
@@ -14,7 +14,7 @@
 #include "servo.hpp"
 
 namespace STATEMANAGER {
-
+    using namespace COMMON;
     struct SteeringServos {
         servo::Servo* left;
         servo::Servo* right;
@@ -28,22 +28,22 @@ namespace STATEMANAGER {
 
         void requestState(const STATE_ESTIMATOR::State& requestedState);
 
-        void setServoSteeringAngle(const COMMON::DriveTrainState& driveTrainState, CONFIG::Handedness side) const;
+        void setServoSteeringAngle(const DriveTrainState& driveTrainState, CONFIG::Handedness side) const;
 
     private:
         MIXER::MixerStrategy *mixerStrategy;
         STATE_ESTIMATOR::StateEstimator *stateEstimator;
-        COMMON::DriveTrainState currentDriveTrainState{};
-        STOKER::Stoker* stokers[COMMON::MOTOR_POSITION::MOTOR_POSITION_COUNT] = {};
+        DriveTrainState currentDriveTrainState{};
+        STOKER::Stoker* stokers[MOTOR_POSITION::MOTOR_POSITION_COUNT] = {};
         SteeringServos steering_servos{};
 
-        COMMON::Observer* observers[COMMON::MOTOR_POSITION::MOTOR_POSITION_COUNT] = {};
+        Observer* observers[MOTOR_POSITION::MOTOR_POSITION_COUNT] = {};
         int observerCount = 0;
 
         // max speed factor - scale the speed of the motors down to this value
         static constexpr float SPEED_EXTENT = 1.0f;
 
-        void setDriveTrainState(const COMMON::DriveTrainState& motorSpeeds);
+        void setDriveTrainState(const DriveTrainState& motorSpeeds);
     };
 
 } // StateManager

--- a/libs/statemanager/include/statemanager.h
+++ b/libs/statemanager/include/statemanager.h
@@ -22,9 +22,9 @@ namespace STATEMANAGER {
 
     class StateManager {
     public:
-        void initialiseServo(servo::Servo*& servo, const uint pin, float minPulse, const float midPulse, const float maxPulse, const float minValue, float midValue, float maxValue);
-
         explicit StateManager(MIXER::MixerStrategy *mixerStrategy, STATE_ESTIMATOR::StateEstimator *stateEstimator);
+
+        void initialiseServo(servo::Servo*& servo, uint pin, float minPulse, float midPulse, float maxPulse, float minValue, float midValue, float maxValue);
 
         void requestState(const STATE_ESTIMATOR::State& requestedState);
 

--- a/libs/statemanager/include/statemanager.h
+++ b/libs/statemanager/include/statemanager.h
@@ -20,13 +20,6 @@ namespace STATEMANAGER {
         servo::Servo* right;
     };
 
-    struct Stokers {
-        STOKER::Stoker* FRONT_LEFT;
-        STOKER::Stoker* FRONT_RIGHT;
-        STOKER::Stoker* REAR_LEFT;
-        STOKER::Stoker* REAR_RIGHT;
-    };
-
     class StateManager {
     public:
         void initialiseServo(servo::Servo*& servo, const uint pin, float minPulse, const float midPulse, const float maxPulse, const float minValue, float midValue, float maxValue);
@@ -41,7 +34,7 @@ namespace STATEMANAGER {
         MIXER::MixerStrategy *mixerStrategy;
         STATE_ESTIMATOR::StateEstimator *stateEstimator;
         COMMON::DriveTrainState currentDriveTrainState{};
-        Stokers stokers{};
+        STOKER::Stoker* stokers[COMMON::MOTOR_POSITION::MOTOR_POSITION_COUNT] = {};
         SteeringServos steering_servos{};
 
         COMMON::Observer* observers[COMMON::MOTOR_POSITION::MOTOR_POSITION_COUNT] = {};

--- a/libs/statemanager/include/statemanager.h
+++ b/libs/statemanager/include/statemanager.h
@@ -5,6 +5,7 @@
 #ifndef OSOD_MOTOR_2040_STATEMANAGER_H
 #define OSOD_MOTOR_2040_STATEMANAGER_H
 
+#include "interfaces.h"
 #include "types.h"
 #include "receiver.h"
 #include "state_estimator.h"
@@ -35,12 +36,17 @@ namespace STATEMANAGER {
         void requestState(const STATE_ESTIMATOR::State& requestedState);
 
         void setServoSteeringAngle(const COMMON::DriveTrainState& driveTrainState, CONFIG::Handedness side) const;
+
     private:
         MIXER::MixerStrategy *mixerStrategy;
         STATE_ESTIMATOR::StateEstimator *stateEstimator;
         COMMON::DriveTrainState currentDriveTrainState{};
         Stokers stokers{};
         SteeringServos steering_servos{};
+
+        COMMON::Observer* observers[COMMON::MOTOR_POSITION::MOTOR_POSITION_COUNT] = {};
+        int observerCount = 0;
+
         // max speed factor - scale the speed of the motors down to this value
         static constexpr float SPEED_EXTENT = 1.0f;
 

--- a/libs/statemanager/src/statemanager.cpp
+++ b/libs/statemanager/src/statemanager.cpp
@@ -24,10 +24,10 @@ namespace STATEMANAGER {
         printf("State estimator created\n");
         printf("State manager created\n");
         // set up the stokers
-        stokers.FRONT_LEFT = new STOKER::Stoker(motor::motor2040::MOTOR_A, Direction::NORMAL_DIR);
-        stokers.FRONT_RIGHT = new STOKER::Stoker(motor::motor2040::MOTOR_B, Direction::NORMAL_DIR);
-        stokers.REAR_LEFT = new STOKER::Stoker(motor::motor2040::MOTOR_C, Direction::NORMAL_DIR);
-        stokers.REAR_RIGHT = new STOKER::Stoker(motor::motor2040::MOTOR_D, Direction::NORMAL_DIR);
+        stokers[COMMON::MOTOR_POSITION::FRONT_LEFT] = new STOKER::Stoker(motor::motor2040::MOTOR_A, COMMON::MOTOR_POSITION::FRONT_LEFT, Direction::NORMAL_DIR);
+        stokers[COMMON::MOTOR_POSITION::FRONT_RIGHT] = new STOKER::Stoker(motor::motor2040::MOTOR_B, COMMON::MOTOR_POSITION::FRONT_RIGHT, Direction::NORMAL_DIR);
+        stokers[COMMON::MOTOR_POSITION::REAR_LEFT] = new STOKER::Stoker(motor::motor2040::MOTOR_C, COMMON::MOTOR_POSITION::REAR_LEFT, Direction::NORMAL_DIR);
+        stokers[COMMON::MOTOR_POSITION::REAR_RIGHT] = new STOKER::Stoker(motor::motor2040::MOTOR_D, COMMON::MOTOR_POSITION::REAR_RIGHT, Direction::NORMAL_DIR);
 
         // set up the servos
         // left - ADC2 / PWM 6 - Pin 28
@@ -71,10 +71,10 @@ namespace STATEMANAGER {
     }
 
     void StateManager::setDriveTrainState(const COMMON::DriveTrainState& motorSpeeds) {
-        stokers.FRONT_LEFT->set_speed(motorSpeeds.speeds[COMMON::MOTOR_POSITION::FRONT_LEFT]);
-        stokers.FRONT_RIGHT->set_speed(motorSpeeds.speeds[COMMON::MOTOR_POSITION::FRONT_RIGHT]);
-        stokers.REAR_LEFT->set_speed(motorSpeeds.speeds[COMMON::MOTOR_POSITION::REAR_LEFT]);
-        stokers.REAR_RIGHT->set_speed(motorSpeeds.speeds[COMMON::MOTOR_POSITION::REAR_RIGHT]);
+        stokers[COMMON::MOTOR_POSITION::FRONT_LEFT]->set_speed(motorSpeeds.speeds[COMMON::MOTOR_POSITION::FRONT_LEFT]);
+        stokers[COMMON::MOTOR_POSITION::FRONT_RIGHT]->set_speed(motorSpeeds.speeds[COMMON::MOTOR_POSITION::FRONT_RIGHT]);
+        stokers[COMMON::MOTOR_POSITION::REAR_LEFT]->set_speed(motorSpeeds.speeds[COMMON::MOTOR_POSITION::REAR_LEFT]);
+        stokers[COMMON::MOTOR_POSITION::REAR_RIGHT]->set_speed(motorSpeeds.speeds[COMMON::MOTOR_POSITION::REAR_RIGHT]);
         setServoSteeringAngle(motorSpeeds, CONFIG::Handedness::LEFT);
         setServoSteeringAngle(motorSpeeds, CONFIG::Handedness::RIGHT);
 

--- a/libs/statemanager/src/statemanager.cpp
+++ b/libs/statemanager/src/statemanager.cpp
@@ -53,11 +53,11 @@ namespace STATEMANAGER {
         if (side == CONFIG::Handedness::LEFT) {
             servo = steering_servos.left;
             angle = driveTrainState.angles.left;
-            speed = driveTrainState.speeds.frontLeft;
+            speed = driveTrainState.speeds[COMMON::MOTOR_POSITION::FRONT_LEFT];
         } else {
             servo = steering_servos.right;
             angle = driveTrainState.angles.right;
-            speed = driveTrainState.speeds.frontRight;
+            speed = driveTrainState.speeds[COMMON::MOTOR_POSITION::FRONT_RIGHT];
         }
 
         if (std::fabs(speed) > 0.05) {
@@ -71,10 +71,10 @@ namespace STATEMANAGER {
     }
 
     void StateManager::setDriveTrainState(const COMMON::DriveTrainState& motorSpeeds) {
-        stokers.FRONT_LEFT->set_requested_speed(motorSpeeds.speeds.frontLeft);
-        stokers.FRONT_RIGHT->set_requested_speed(motorSpeeds.speeds.frontRight);
-        stokers.REAR_LEFT->set_requested_speed(motorSpeeds.speeds.rearLeft);
-        stokers.REAR_RIGHT->set_requested_speed(motorSpeeds.speeds.rearRight);
+        stokers.FRONT_LEFT->set_speed(motorSpeeds.speeds[COMMON::MOTOR_POSITION::FRONT_LEFT]);
+        stokers.FRONT_RIGHT->set_speed(motorSpeeds.speeds[COMMON::MOTOR_POSITION::FRONT_RIGHT]);
+        stokers.REAR_LEFT->set_speed(motorSpeeds.speeds[COMMON::MOTOR_POSITION::REAR_LEFT]);
+        stokers.REAR_RIGHT->set_speed(motorSpeeds.speeds[COMMON::MOTOR_POSITION::REAR_RIGHT]);
         setServoSteeringAngle(motorSpeeds, CONFIG::Handedness::LEFT);
         setServoSteeringAngle(motorSpeeds, CONFIG::Handedness::RIGHT);
 

--- a/libs/statemanager/src/statemanager.cpp
+++ b/libs/statemanager/src/statemanager.cpp
@@ -43,7 +43,6 @@ namespace STATEMANAGER {
         //printf("\n");
         const COMMON::DriveTrainState driveTrainState = mixerStrategy->mix(requestedState.velocity, requestedState.angularVelocity);
         setDriveTrainState(driveTrainState);
-        currentDriveTrainState = driveTrainState;
     }
 
     void StateManager::setServoSteeringAngle(const COMMON::DriveTrainState& driveTrainState, const CONFIG::Handedness side) const {
@@ -72,10 +71,10 @@ namespace STATEMANAGER {
     }
 
     void StateManager::setDriveTrainState(const COMMON::DriveTrainState& motorSpeeds) {
-        stokers.FRONT_LEFT->set_speed(motorSpeeds.speeds.frontLeft);
-        stokers.FRONT_RIGHT->set_speed(motorSpeeds.speeds.frontRight);
-        stokers.REAR_LEFT->set_speed(motorSpeeds.speeds.rearLeft);
-        stokers.REAR_RIGHT->set_speed(motorSpeeds.speeds.rearRight);
+        stokers.FRONT_LEFT->set_requested_speed(motorSpeeds.speeds.frontLeft);
+        stokers.FRONT_RIGHT->set_requested_speed(motorSpeeds.speeds.frontRight);
+        stokers.REAR_LEFT->set_requested_speed(motorSpeeds.speeds.rearLeft);
+        stokers.REAR_RIGHT->set_requested_speed(motorSpeeds.speeds.rearRight);
         setServoSteeringAngle(motorSpeeds, CONFIG::Handedness::LEFT);
         setServoSteeringAngle(motorSpeeds, CONFIG::Handedness::RIGHT);
 

--- a/libs/statemanager/src/statemanager.cpp
+++ b/libs/statemanager/src/statemanager.cpp
@@ -24,10 +24,10 @@ namespace STATEMANAGER {
         printf("State estimator created\n");
         printf("State manager created\n");
         // set up the stokers
-        stokers[COMMON::MOTOR_POSITION::FRONT_LEFT] = new STOKER::Stoker(motor::motor2040::MOTOR_A, COMMON::MOTOR_POSITION::FRONT_LEFT, Direction::NORMAL_DIR);
-        stokers[COMMON::MOTOR_POSITION::FRONT_RIGHT] = new STOKER::Stoker(motor::motor2040::MOTOR_B, COMMON::MOTOR_POSITION::FRONT_RIGHT, Direction::NORMAL_DIR);
-        stokers[COMMON::MOTOR_POSITION::REAR_LEFT] = new STOKER::Stoker(motor::motor2040::MOTOR_C, COMMON::MOTOR_POSITION::REAR_LEFT, Direction::NORMAL_DIR);
-        stokers[COMMON::MOTOR_POSITION::REAR_RIGHT] = new STOKER::Stoker(motor::motor2040::MOTOR_D, COMMON::MOTOR_POSITION::REAR_RIGHT, Direction::NORMAL_DIR);
+        stokers[MOTOR_POSITION::FRONT_LEFT] = new STOKER::Stoker(motor::motor2040::MOTOR_A, MOTOR_POSITION::FRONT_LEFT, Direction::NORMAL_DIR);
+        stokers[MOTOR_POSITION::FRONT_RIGHT] = new STOKER::Stoker(motor::motor2040::MOTOR_B, MOTOR_POSITION::FRONT_RIGHT, Direction::NORMAL_DIR);
+        stokers[MOTOR_POSITION::REAR_LEFT] = new STOKER::Stoker(motor::motor2040::MOTOR_C, MOTOR_POSITION::REAR_LEFT, Direction::NORMAL_DIR);
+        stokers[MOTOR_POSITION::REAR_RIGHT] = new STOKER::Stoker(motor::motor2040::MOTOR_D, MOTOR_POSITION::REAR_RIGHT, Direction::NORMAL_DIR);
 
         // set up the servos
         // left - ADC2 / PWM 6 - Pin 28
@@ -41,11 +41,11 @@ namespace STATEMANAGER {
         //printf("Velocity: %f ", requestedState.velocity);
         //printf("Angular velocity: %f ", requestedState.angularVelocity);
         //printf("\n");
-        const COMMON::DriveTrainState driveTrainState = mixerStrategy->mix(requestedState.velocity, requestedState.angularVelocity);
+        const DriveTrainState driveTrainState = mixerStrategy->mix(requestedState.velocity, requestedState.angularVelocity);
         setDriveTrainState(driveTrainState);
     }
 
-    void StateManager::setServoSteeringAngle(const COMMON::DriveTrainState& driveTrainState, const CONFIG::Handedness side) const {
+    void StateManager::setServoSteeringAngle(const DriveTrainState& driveTrainState, const CONFIG::Handedness side) const {
         servo::Servo *servo;
         float angle;
         float speed;
@@ -53,11 +53,11 @@ namespace STATEMANAGER {
         if (side == CONFIG::Handedness::LEFT) {
             servo = steering_servos.left;
             angle = driveTrainState.angles.left;
-            speed = driveTrainState.speeds[COMMON::MOTOR_POSITION::FRONT_LEFT];
+            speed = driveTrainState.speeds[MOTOR_POSITION::FRONT_LEFT];
         } else {
             servo = steering_servos.right;
             angle = driveTrainState.angles.right;
-            speed = driveTrainState.speeds[COMMON::MOTOR_POSITION::FRONT_RIGHT];
+            speed = driveTrainState.speeds[MOTOR_POSITION::FRONT_RIGHT];
         }
 
         if (std::fabs(speed) > 0.05) {
@@ -70,11 +70,11 @@ namespace STATEMANAGER {
         }
     }
 
-    void StateManager::setDriveTrainState(const COMMON::DriveTrainState& motorSpeeds) {
-        stokers[COMMON::MOTOR_POSITION::FRONT_LEFT]->set_speed(motorSpeeds.speeds[COMMON::MOTOR_POSITION::FRONT_LEFT]);
-        stokers[COMMON::MOTOR_POSITION::FRONT_RIGHT]->set_speed(motorSpeeds.speeds[COMMON::MOTOR_POSITION::FRONT_RIGHT]);
-        stokers[COMMON::MOTOR_POSITION::REAR_LEFT]->set_speed(motorSpeeds.speeds[COMMON::MOTOR_POSITION::REAR_LEFT]);
-        stokers[COMMON::MOTOR_POSITION::REAR_RIGHT]->set_speed(motorSpeeds.speeds[COMMON::MOTOR_POSITION::REAR_RIGHT]);
+    void StateManager::setDriveTrainState(const DriveTrainState& motorSpeeds) {
+        stokers[MOTOR_POSITION::FRONT_LEFT]->set_speed(motorSpeeds.speeds[MOTOR_POSITION::FRONT_LEFT]);
+        stokers[MOTOR_POSITION::FRONT_RIGHT]->set_speed(motorSpeeds.speeds[MOTOR_POSITION::FRONT_RIGHT]);
+        stokers[MOTOR_POSITION::REAR_LEFT]->set_speed(motorSpeeds.speeds[MOTOR_POSITION::REAR_LEFT]);
+        stokers[MOTOR_POSITION::REAR_RIGHT]->set_speed(motorSpeeds.speeds[MOTOR_POSITION::REAR_RIGHT]);
         setServoSteeringAngle(motorSpeeds, CONFIG::Handedness::LEFT);
         setServoSteeringAngle(motorSpeeds, CONFIG::Handedness::RIGHT);
 

--- a/libs/stoker/CMakeLists.txt
+++ b/libs/stoker/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(stoker STATIC
 )
 
 target_link_libraries(stoker PUBLIC
+        common
         motor
 )
 

--- a/libs/stoker/include/stoker.h
+++ b/libs/stoker/include/stoker.h
@@ -15,14 +15,15 @@ namespace STOKER {
         ~Stoker() = default;
 
     public:
-        Stoker(const pin_pair &pins, Direction direction);
+        Stoker(const pin_pair &pins, COMMON::MOTOR_POSITION::MotorPosition position, Direction direction);
         void set_speed(float speed);
 
         void update(COMMON::DriveTrainState newState) override;
 
     private:
         motor::Motor motor;
-        COMMON::MotorSpeeds current_motor_speeds_;
+        float current_motor_speed = 0.0f;
+        COMMON::MOTOR_POSITION::MotorPosition motor_position_;
     };
 
 } // STOKER

--- a/libs/stoker/include/stoker.h
+++ b/libs/stoker/include/stoker.h
@@ -5,17 +5,24 @@
 #ifndef OSOD_MOTOR_2040_STOKER_H
 #define OSOD_MOTOR_2040_STOKER_H
 
+#include "interfaces.h"
 #include "drivers/motor/motor.hpp"
 
 namespace STOKER {
 
-    class Stoker {
+    class Stoker: public COMMON::Observer {
+    protected:
+        ~Stoker() = default;
+
     public:
         Stoker(const pin_pair &pins, Direction direction);
         void set_speed(float speed);
 
+        void update(COMMON::DriveTrainState newState) override;
+
     private:
         motor::Motor motor;
+        COMMON::MotorSpeeds current_motor_speeds_;
     };
 
 } // STOKER

--- a/libs/stoker/include/stoker.h
+++ b/libs/stoker/include/stoker.h
@@ -9,21 +9,21 @@
 #include "drivers/motor/motor.hpp"
 
 namespace STOKER {
-
-    class Stoker: public COMMON::Observer {
+    using namespace COMMON;
+    class Stoker: public Observer {
     protected:
         ~Stoker() = default;
 
     public:
-        Stoker(const pin_pair &pins, COMMON::MOTOR_POSITION::MotorPosition position, Direction direction);
+        Stoker(const pin_pair &pins, MOTOR_POSITION::MotorPosition position, Direction direction);
         void set_speed(float speed);
 
-        void update(COMMON::DriveTrainState newState) override;
+        void update(DriveTrainState newState) override;
 
     private:
         motor::Motor motor;
         float current_motor_speed = 0.0f;
-        COMMON::MOTOR_POSITION::MotorPosition motor_position_;
+        MOTOR_POSITION::MotorPosition motor_position_;
     };
 
 } // STOKER

--- a/libs/stoker/src/stoker.cpp
+++ b/libs/stoker/src/stoker.cpp
@@ -5,7 +5,7 @@
 #include "../include/stoker.h"
 
 namespace STOKER {
-    Stoker::Stoker(const pin_pair &pins, const COMMON::MOTOR_POSITION::MotorPosition position, Direction direction = Direction::NORMAL_DIR) : motor(pins), motor_position_(position) {
+    Stoker::Stoker(const pin_pair &pins, const MOTOR_POSITION::MotorPosition position, Direction direction = Direction::NORMAL_DIR) : motor(pins), motor_position_(position) {
         motor.init();
     }
 
@@ -14,7 +14,7 @@ namespace STOKER {
 
     }
 
-    void Stoker::update(const COMMON::DriveTrainState newState) {
+    void Stoker::update(const DriveTrainState newState) {
         current_motor_speed = newState.speeds[motor_position_];
     }
 

--- a/libs/stoker/src/stoker.cpp
+++ b/libs/stoker/src/stoker.cpp
@@ -13,4 +13,9 @@ namespace STOKER {
         motor.speed(speed);
 
     }
+
+    void Stoker::update(COMMON::DriveTrainState newState) {
+        current_motor_speeds_ = newState.speeds;
+    }
+
 } // STOKER

--- a/libs/stoker/src/stoker.cpp
+++ b/libs/stoker/src/stoker.cpp
@@ -5,17 +5,17 @@
 #include "../include/stoker.h"
 
 namespace STOKER {
-    Stoker::Stoker(const pin_pair &pins, Direction direction = Direction::NORMAL_DIR) : motor(pins) {
+    Stoker::Stoker(const pin_pair &pins, const COMMON::MOTOR_POSITION::MotorPosition position, Direction direction = Direction::NORMAL_DIR) : motor(pins), motor_position_(position) {
         motor.init();
     }
 
-    void Stoker::set_speed(float speed) {
+    void Stoker::set_speed(const float speed) {
         motor.speed(speed);
 
     }
 
-    void Stoker::update(COMMON::DriveTrainState newState) {
-        current_motor_speeds_ = newState.speeds;
+    void Stoker::update(const COMMON::DriveTrainState newState) {
+        current_motor_speed = newState.speeds[motor_position_];
     }
 
 } // STOKER


### PR DESCRIPTION
A stab at updating the stokers with the latest estimated state, using the Observer pattern.

Things of note:

- introduces `Subject` and `Observer` interfaces
- `StateEstimator` implements `Subject`, maintains list of observers
- `Stoker` implements `Observer`
- `StateEstimator` notifies all observers when new state is estimated
- introduced a `MOTOR_POSITION` enum, and updated `MotorSpeeds` to use it
- `Stoker` has a `position` property that it uses to pull the correct value from the new state payload when updated

I didn't go the whole hog and replace the `StateEstimator` updating with the command pattern. It seemed like unnecessary noise at this point, as this branch was already getting a bit busy.

addresses #29