### PR TITLE
break up estimateState into smaller chunks

### DIFF
--- a/libs/common/include/types.h
+++ b/libs/common/include/types.h
@@ -36,6 +36,19 @@ namespace COMMON {
         MotorSpeeds speeds;
         SteeringAngles angles;
     };
+
+    struct Odometry {
+        float x;
+        float y;
+        float heading;
+    };
+
+    struct Velocity {
+        float x_dot;
+        float y_dot;
+        float velocity;
+        float angular_velocity;
+    };
 }
 
 #endif //OSOD_MOTOR_2040_TYPES_H

--- a/libs/navigator/src/navigator.cpp
+++ b/libs/navigator/src/navigator.cpp
@@ -27,8 +27,8 @@ void Navigator::navigate() {
         // send the receiver data to the state manager
         // TODO: use a queue to send the receiver data to the state manager
         STATE_ESTIMATOR::State requestedState{};
-        requestedState.velocity = values.ELE * CONFIG::MAX_VELOCITY;
-        requestedState.angularVelocity = values.AIL * CONFIG::MAX_ANGULAR_VELOCITY;
+        requestedState.velocity.velocity = values.ELE * CONFIG::MAX_VELOCITY;
+        requestedState.velocity.angular_velocity = values.AIL * CONFIG::MAX_ANGULAR_VELOCITY;
         pStateManager->requestState(requestedState);
     } else {
         printf("No receiver data available\n");

--- a/libs/state_estimator/include/state_estimator.h
+++ b/libs/state_estimator/include/state_estimator.h
@@ -82,6 +82,8 @@ namespace STATE_ESTIMATOR {
         Velocity calculate_velocities(float heading, float left_speed, float right_speed);
 
         static MotorSpeeds get_wheel_speeds(const Encoder::Capture* encoderCaptures);
+
+        [[nodiscard]] SteeringAngles estimate_steering_angles() const;
     };
 } // STATE_ESTIMATOR
 

--- a/libs/state_estimator/include/state_estimator.h
+++ b/libs/state_estimator/include/state_estimator.h
@@ -49,7 +49,7 @@ namespace STATE_ESTIMATOR {
 
         void notifyObservers(DriveTrainState newState) override;
 
-        void updateCurrentDriveTrainState(const DriveTrainState& newDriveTrainState);
+        void updateCurrentSteeringAngles(const SteeringAngles& newSteeringAngles);
 
         static float wrap_pi(float heading);
 
@@ -63,6 +63,7 @@ namespace STATE_ESTIMATOR {
         State estimatedState;
         State previousState;
         DriveTrainState currentDriveTrainState;
+        SteeringAngles currentSteeringAngles;
 
         static void timerCallback(repeating_timer_t* timer);
 

--- a/libs/state_estimator/include/state_estimator.h
+++ b/libs/state_estimator/include/state_estimator.h
@@ -14,15 +14,17 @@
 
 using namespace motor;
 using namespace encoder;
+
 struct Encoders {
-    Encoder *FRONT_LEFT;
-    Encoder *FRONT_RIGHT;
-    Encoder *REAR_LEFT;
-    Encoder *REAR_RIGHT;
+    Encoder* FRONT_LEFT;
+    Encoder* FRONT_RIGHT;
+    Encoder* REAR_LEFT;
+    Encoder* REAR_RIGHT;
 };
 
 namespace STATE_ESTIMATOR {
     using namespace COMMON;
+
     // define a State struct containing the state parameters that can be requested or tracked
     struct State {
         float x;
@@ -34,40 +36,57 @@ namespace STATE_ESTIMATOR {
         float angularVelocity;
         DriveTrainState driveTrainState;
     };
-    class StateEstimator: public Subject {
+
+    class StateEstimator : public Subject {
     public:
         explicit StateEstimator();
 
     protected:
-        ~StateEstimator();  // Destructor to cancel the timer
+        ~StateEstimator(); // Destructor to cancel the timer
     public:
         void showValues() const;
+
         void estimateState();
+
         void publishState() const;
+
         void addObserver(Observer* observer) override;
+
         void notifyObservers(DriveTrainState newState) override;
+
+        void updateCurrentDriveTrainState(const DriveTrainState& newDriveTrainState);
+
+        static float wrap_pi(float heading);
+
+        void calculate_bilateral_speeds(const MotorSpeeds& motor_speeds, SteeringAngles steering_angles,
+                                        float& left_speed, float& right_speed);
 
     private:
         Encoder* encoders[MOTOR_POSITION::MOTOR_POSITION_COUNT];
-        static StateEstimator *instancePtr;
-        repeating_timer_t *timer;
+        static StateEstimator* instancePtr;
+        repeating_timer_t* timer;
         State estimatedState;
         State previousState;
         DriveTrainState currentDriveTrainState;
-        static void timerCallback(repeating_timer_t *timer);
 
-    public:
-        void updateCurrentDriveTrainState(const DriveTrainState& newDriveTrainState);
+        static void timerCallback(repeating_timer_t* timer);
 
-    private:
         void setupTimer() const;
+
         Observer* observers[10] = {};
         int observerCount = 0;
 
+        void StateEstimator::capture_encoders(Encoder::Capture* encoderCaptures) const;
 
+        void StateEstimator::get_position_deltas(Encoder::Capture encoderCaptures[4], float& distance_travelled,
+                                                 float& heading_change) const;
 
+        void calculate_new_position_orientation(State& tmpState, float distance_travelled, float heading_change);
+
+        void calculate_velocities(State& tmpState, float left_speed, float right_speed);
+
+        static MotorSpeeds get_wheel_speeds(const Encoder::Capture* encoderCaptures);
     };
-
 } // STATE_ESTIMATOR
 
 #endif //OSOD_MOTOR_2040_STATE_ESTIMATOR_H

--- a/libs/state_estimator/include/state_estimator.h
+++ b/libs/state_estimator/include/state_estimator.h
@@ -48,7 +48,7 @@ namespace STATE_ESTIMATOR {
         void notifyObservers(DriveTrainState newState) override;
 
     private:
-        Encoders encoders;
+        Encoder* encoders[MOTOR_POSITION::MOTOR_POSITION_COUNT];
         static StateEstimator *instancePtr;
         repeating_timer_t *timer;
         State estimatedState;
@@ -61,7 +61,7 @@ namespace STATE_ESTIMATOR {
 
     private:
         void setupTimer() const;
-        Observer* observers[10];
+        Observer* observers[10] = {};
         int observerCount = 0;
 
 

--- a/libs/state_estimator/include/state_estimator.h
+++ b/libs/state_estimator/include/state_estimator.h
@@ -27,13 +27,8 @@ namespace STATE_ESTIMATOR {
 
     // define a State struct containing the state parameters that can be requested or tracked
     struct State {
-        float x;
-        float xdot;
-        float y;
-        float ydot;
-        float velocity;
-        float heading;
-        float angularVelocity;
+        Velocity velocity;
+        Odometry odometry;
         DriveTrainState driveTrainState;
     };
 
@@ -76,14 +71,14 @@ namespace STATE_ESTIMATOR {
         Observer* observers[10] = {};
         int observerCount = 0;
 
-        void StateEstimator::capture_encoders(Encoder::Capture* encoderCaptures) const;
+        void capture_encoders(Encoder::Capture* encoderCaptures) const;
 
-        void StateEstimator::get_position_deltas(Encoder::Capture encoderCaptures[4], float& distance_travelled,
+        void get_position_deltas(Encoder::Capture encoderCaptures[4], float& distance_travelled,
                                                  float& heading_change) const;
 
         void calculate_new_position_orientation(State& tmpState, float distance_travelled, float heading_change);
 
-        void calculate_velocities(State& tmpState, float left_speed, float right_speed);
+        Velocity calculate_velocities(float heading, float left_speed, float right_speed);
 
         static MotorSpeeds get_wheel_speeds(const Encoder::Capture* encoderCaptures);
     };

--- a/libs/state_estimator/src/state_estimator.cpp
+++ b/libs/state_estimator/src/state_estimator.cpp
@@ -9,15 +9,15 @@ namespace STATE_ESTIMATOR {
     StateEstimator *StateEstimator::instancePtr = nullptr;
 
     StateEstimator::StateEstimator() : encoders{
-            .FRONT_LEFT =new Encoder(pio0, 0, motor2040::ENCODER_A, PIN_UNUSED, Direction::NORMAL_DIR, CONFIG::COUNTS_PER_REV),
-            .FRONT_RIGHT =new Encoder(pio0, 1, motor2040::ENCODER_B, PIN_UNUSED, Direction::NORMAL_DIR, CONFIG::COUNTS_PER_REV),
-            .REAR_LEFT = new Encoder(pio0, 2, motor2040::ENCODER_C, PIN_UNUSED, Direction::NORMAL_DIR, CONFIG::COUNTS_PER_REV),
-            .REAR_RIGHT = new Encoder(pio0, 3, motor2040::ENCODER_D, PIN_UNUSED, Direction::NORMAL_DIR, CONFIG::COUNTS_PER_REV)
-    }, timer(new repeating_timer_t) {
-        encoders.FRONT_LEFT->init();
-        encoders.FRONT_RIGHT->init();
-        encoders.REAR_LEFT->init();
-        encoders.REAR_RIGHT->init();
+            [MOTOR_POSITION::FRONT_LEFT] =new Encoder(pio0, 0, motor2040::ENCODER_A, PIN_UNUSED, Direction::NORMAL_DIR, CONFIG::COUNTS_PER_REV),
+            [MOTOR_POSITION::FRONT_RIGHT] =new Encoder(pio0, 1, motor2040::ENCODER_B, PIN_UNUSED, Direction::NORMAL_DIR, CONFIG::COUNTS_PER_REV),
+            [MOTOR_POSITION::REAR_LEFT] = new Encoder(pio0, 2, motor2040::ENCODER_C, PIN_UNUSED, Direction::NORMAL_DIR, CONFIG::COUNTS_PER_REV),
+            [MOTOR_POSITION::REAR_RIGHT] = new Encoder(pio0, 3, motor2040::ENCODER_D, PIN_UNUSED, Direction::NORMAL_DIR, CONFIG::COUNTS_PER_REV)
+    }, timer(new repeating_timer_t), estimatedState(), previousState(), currentDriveTrainState() {
+        encoders[MOTOR_POSITION::FRONT_LEFT]->init();
+        encoders[MOTOR_POSITION::FRONT_RIGHT]->init();
+        encoders[MOTOR_POSITION::REAR_LEFT]->init();
+        encoders[MOTOR_POSITION::REAR_RIGHT]->init();
 
         // Initialize the State struct member variables
         estimatedState.x = 0.0f;
@@ -39,10 +39,10 @@ namespace STATE_ESTIMATOR {
     }
 
     void StateEstimator::showValues() const {
-        printf("FRONT_LEFT: %ld ", encoders.FRONT_LEFT->count());
-        printf("FRONT_RIGHT: %ld ", encoders.FRONT_RIGHT->count());
-        printf("REAR_LEFT: %ld ", encoders.REAR_LEFT->count());
-        printf("REAR_RIGHT: %ld ", encoders.REAR_RIGHT->count());
+        printf("FRONT_LEFT: %ld ", encoders[MOTOR_POSITION::FRONT_LEFT]->count());
+        printf("FRONT_RIGHT: %ld ", encoders[MOTOR_POSITION::FRONT_RIGHT]->count());
+        printf("REAR_LEFT: %ld ", encoders[MOTOR_POSITION::REAR_LEFT]->count());
+        printf("REAR_RIGHT: %ld ", encoders[MOTOR_POSITION::REAR_RIGHT]->count());
         printf("\n");
         printf("X: %f, Y: %f, Velocity: %f, Heading: %f, turn rate: %f\n", 
            estimatedState.x, 
@@ -71,10 +71,10 @@ namespace STATE_ESTIMATOR {
     void StateEstimator::estimateState() {
         
         //get current encoder state
-        const auto captureFL = encoders.FRONT_LEFT->capture();
-        const auto captureFR = encoders.FRONT_RIGHT->capture();
-        const auto captureRL = encoders.REAR_LEFT->capture();
-        const auto captureRR = encoders.REAR_RIGHT->capture();
+        const auto captureFL = encoders[MOTOR_POSITION::FRONT_LEFT]->capture();
+        const auto captureFR = encoders[MOTOR_POSITION::FRONT_RIGHT]->capture();
+        const auto captureRL = encoders[MOTOR_POSITION::REAR_LEFT]->capture();
+        const auto captureRR = encoders[MOTOR_POSITION::REAR_RIGHT]->capture();
         
         // calculate position deltas
 
@@ -171,10 +171,10 @@ namespace STATE_ESTIMATOR {
     }
 
     StateEstimator::~StateEstimator() {
-        delete encoders.FRONT_LEFT;
-        delete encoders.FRONT_RIGHT;
-        delete encoders.REAR_LEFT;
-        delete encoders.REAR_RIGHT;
+        delete encoders[MOTOR_POSITION::FRONT_LEFT];
+        delete encoders[MOTOR_POSITION::FRONT_RIGHT];
+        delete encoders[MOTOR_POSITION::REAR_LEFT];
+        delete encoders[MOTOR_POSITION::REAR_RIGHT];
         // Cancel the timer in the destructor
         cancel_repeating_timer(timer);
 

--- a/libs/state_estimator/src/state_estimator.cpp
+++ b/libs/state_estimator/src/state_estimator.cpp
@@ -205,8 +205,8 @@ namespace STATE_ESTIMATOR {
         }
     }
 
-    void StateEstimator::updateCurrentDriveTrainState(const DriveTrainState& newDriveTrainState) {
-        currentDriveTrainState = newDriveTrainState;
+    void StateEstimator::updateCurrentSteeringAngles(const SteeringAngles& newSteeringAngles) {
+        currentSteeringAngles = newSteeringAngles;
     }
 
     StateEstimator::~StateEstimator() {

--- a/libs/state_estimator/src/state_estimator.cpp
+++ b/libs/state_estimator/src/state_estimator.cpp
@@ -148,6 +148,10 @@ namespace STATE_ESTIMATOR {
         return wheelSpeeds;
     }
 
+    SteeringAngles StateEstimator::estimate_steering_angles() const {
+        return currentSteeringAngles;
+    }
+
     void StateEstimator::estimateState() {
         // instantiate a copy of the current state
         State tmpState = estimatedState;
@@ -169,6 +173,9 @@ namespace STATE_ESTIMATOR {
 
         //get wheel speeds
         tmpState.driveTrainState.speeds = get_wheel_speeds(encoderCaptures);
+
+        // estimate steering angles
+        tmpState.driveTrainState.angles = estimate_steering_angles();
 
         // calculate left and right speeds
         float left_speed;

--- a/libs/statemanager/src/statemanager.cpp
+++ b/libs/statemanager/src/statemanager.cpp
@@ -41,7 +41,7 @@ namespace STATEMANAGER {
         //printf("Velocity: %f ", requestedState.velocity);
         //printf("Angular velocity: %f ", requestedState.angularVelocity);
         //printf("\n");
-        const DriveTrainState driveTrainState = mixerStrategy->mix(requestedState.velocity, requestedState.angularVelocity);
+        const DriveTrainState driveTrainState = mixerStrategy->mix(requestedState.velocity.velocity, requestedState.velocity.angular_velocity);
         setDriveTrainState(driveTrainState);
     }
 

--- a/libs/statemanager/src/statemanager.cpp
+++ b/libs/statemanager/src/statemanager.cpp
@@ -81,7 +81,7 @@ namespace STATEMANAGER {
         // save the current state
         currentDriveTrainState = motorSpeeds;
 
-        // update the state estimator with the current state
-        stateEstimator->updateCurrentDriveTrainState(motorSpeeds);
+        // update the state estimator with the current steering angles
+        stateEstimator->updateCurrentSteeringAngles(motorSpeeds.angles);
     }
 } // StateManager


### PR DESCRIPTION
refactor estimateState into smaller pieces, using helper methods. there's still a little way to go, by rationalising the `State` struct, which will help to clean things up a bit, but this is a good start for comment.

note that it is based on #38, so cannot be merged until that is.