### PR TITLE
Pin pico-cppm version

### DIFF
--- a/libs/receiver/CMakeLists.txt
+++ b/libs/receiver/CMakeLists.txt
@@ -23,7 +23,7 @@ target_include_directories(receiver PUBLIC
     FetchContent_Declare(
             pico_cppm
             GIT_REPOSITORY "https://github.com/cadouthat/pico-cppm"
-            GIT_TAG "main"
+            GIT_TAG "cf1222eb773ba61cc27c9d7d2c3aa3aa855cf74c"
     )
 
     FetchContent_GetProperties(pico-cppm)


### PR DESCRIPTION
Pin the version of `pico_cppm` pulled down by fetctcontent to the latest version that we've tested.

Fixes #51