### PR TITLE
Allow us to set which end of the robot is considered the front

### DIFF
--- a/libs/config/include/drivetrain_config.h
+++ b/libs/config/include/drivetrain_config.h
@@ -24,6 +24,12 @@ namespace CONFIG {
         RIGHT
     };
 
+
+    enum DrivingDirection {
+        SteerableWheelsAtFront,
+        SteerableWheelsAtRear
+    };
+
     // chassis geometry
     constexpr float WHEEL_BASE = 0.18f; // metres
     constexpr float WHEEL_TRACK = 0.15f; // metres
@@ -59,19 +65,24 @@ namespace CONFIG {
     #if (CURRENT_CHALLENGE == ECO_DISASTER)
         constexpr float WHEEL_DIAMETER = LARGE_WHEEL_DIAMETER;
         constexpr float GEAR_RATIO = 42.0 / 18.0 * GEARMOTOR_RATIO;
+        constexpr DrivingDirection DRIVING_DIRECTION = SteerableWheelsAtRear;
     #elif (CURRENT_CHALLENGE == ESCAPE_ROUTE || CURRENT_CHALLENGE == MINESWEEPER || CURRENT_CHALLENGE == ZOMBIE_APOCALYPSE)
         const float WHEEL_DIAMETER = SMALL_WHEEL_DIAMETER;
         const float GEAR_RATIO = GEARMOTOR_RATIO;
+        constexpr DrivingDirection DRIVING_DIRECTION = SteerableWheelsAtFront;
     #elif (CURRENT_CHALLENGE == PI_NOON)
         const float WHEEL_DIAMETER = MECANUM_DIAMETER;
         const float GEAR_RATIO = GEARMOTOR_RATIO;
+        constexpr DrivingDirection DRIVING_DIRECTION = SteerableWheelsAtFront;
     #elif  (CURRENT_CHALLENGE == LAVA_PALAVA || CURRENT_CHALLENGE == TEMPLE_OF_DOOM)
         const float WHEEL_DIAMETER = LARGE_WHEEL_DIAMETER;
         const float GEAR_RATIO = GEARMOTOR_RATIO;
+        constexpr DrivingDirection DRIVING_DIRECTION = SteerableWheelsAtFront;
     #else
         // Default case
         const float WHEEL_DIAMETER = SMALL_WHEEL_DIAMETER;
         const float GEAR_RATIO = GEARMOTOR_RATIO;
+        constexpr DrivingDirection DRIVING_DIRECTION = SteerableWheelsAtFront;
     #endif
 
 

--- a/libs/config/include/drivetrain_config.h
+++ b/libs/config/include/drivetrain_config.h
@@ -64,19 +64,19 @@ namespace CONFIG {
     #if (CURRENT_CHALLENGE == ECO_DISASTER)
         constexpr float WHEEL_DIAMETER = LARGE_WHEEL_DIAMETER;
         constexpr float GEAR_RATIO = 42.0 / 18.0 * GEARMOTOR_RATIO;
-        constexpr SteeringStyle DRIVING_DIRECTION = ForkliftSteering;
+        constexpr SteeringStyle DRIVING_STYLE = Forklift;
     #elif (CURRENT_CHALLENGE == ESCAPE_ROUTE || CURRENT_CHALLENGE == MINESWEEPER || CURRENT_CHALLENGE == ZOMBIE_APOCALYPSE)
         const float WHEEL_DIAMETER = SMALL_WHEEL_DIAMETER;
         const float GEAR_RATIO = GEARMOTOR_RATIO;
-        constexpr SteeringStyle DRIVING_DIRECTION = CarSteering;
+        constexpr SteeringStyle DRIVING_STYLE = Car;
     #elif (CURRENT_CHALLENGE == PI_NOON)
         const float WHEEL_DIAMETER = MECANUM_DIAMETER;
         const float GEAR_RATIO = GEARMOTOR_RATIO;
-        constexpr SteeringStyle DRIVING_DIRECTION = CarSteering;
+        constexpr SteeringStyle DRIVING_STYLE = Car;
     #elif  (CURRENT_CHALLENGE == LAVA_PALAVA || CURRENT_CHALLENGE == TEMPLE_OF_DOOM)
         const float WHEEL_DIAMETER = LARGE_WHEEL_DIAMETER;
         const float GEAR_RATIO = GEARMOTOR_RATIO;
-        constexpr SteeringStyle DRIVING_DIRECTION = CarSteering;
+        constexpr SteeringStyle DRIVING_STYLE = Car;
     #else
         // Default case
         const float WHEEL_DIAMETER = SMALL_WHEEL_DIAMETER;

--- a/libs/config/include/drivetrain_config.h
+++ b/libs/config/include/drivetrain_config.h
@@ -25,9 +25,9 @@ namespace CONFIG {
     };
 
 
-    enum DrivingDirection {
-        CarSteering = 1,
-        ForkliftSteering = -1
+    enum SteeringStyle {
+        Car = 1,
+        Forklift = -1
     };
 
     // chassis geometry
@@ -65,24 +65,24 @@ namespace CONFIG {
     #if (CURRENT_CHALLENGE == ECO_DISASTER)
         constexpr float WHEEL_DIAMETER = LARGE_WHEEL_DIAMETER;
         constexpr float GEAR_RATIO = 42.0 / 18.0 * GEARMOTOR_RATIO;
-        constexpr DrivingDirection DRIVING_DIRECTION = ForkliftSteering;
+        constexpr SteeringStyle DRIVING_DIRECTION = ForkliftSteering;
     #elif (CURRENT_CHALLENGE == ESCAPE_ROUTE || CURRENT_CHALLENGE == MINESWEEPER || CURRENT_CHALLENGE == ZOMBIE_APOCALYPSE)
         const float WHEEL_DIAMETER = SMALL_WHEEL_DIAMETER;
         const float GEAR_RATIO = GEARMOTOR_RATIO;
-        constexpr DrivingDirection DRIVING_DIRECTION = CarSteering;
+        constexpr SteeringStyle DRIVING_DIRECTION = CarSteering;
     #elif (CURRENT_CHALLENGE == PI_NOON)
         const float WHEEL_DIAMETER = MECANUM_DIAMETER;
         const float GEAR_RATIO = GEARMOTOR_RATIO;
-        constexpr DrivingDirection DRIVING_DIRECTION = CarSteering;
+        constexpr SteeringStyle DRIVING_DIRECTION = CarSteering;
     #elif  (CURRENT_CHALLENGE == LAVA_PALAVA || CURRENT_CHALLENGE == TEMPLE_OF_DOOM)
         const float WHEEL_DIAMETER = LARGE_WHEEL_DIAMETER;
         const float GEAR_RATIO = GEARMOTOR_RATIO;
-        constexpr DrivingDirection DRIVING_DIRECTION = CarSteering;
+        constexpr SteeringStyle DRIVING_DIRECTION = CarSteering;
     #else
         // Default case
         const float WHEEL_DIAMETER = SMALL_WHEEL_DIAMETER;
         const float GEAR_RATIO = GEARMOTOR_RATIO;
-        constexpr DrivingDirection DRIVING_DIRECTION = CarSteering;
+        constexpr SteeringStyle DRIVING_DIRECTION = CarSteering;
     #endif
 
 

--- a/libs/config/include/drivetrain_config.h
+++ b/libs/config/include/drivetrain_config.h
@@ -13,7 +13,7 @@ namespace CONFIG {
     #define PI_NOON 5
     #define TEMPLE_OF_DOOM 6
 
-    #define CURRENT_CHALLENGE ECO_DISASTER
+    #define CURRENT_CHALLENGE ESCAPE_ROUTE //ECO_DISASTER
 
     constexpr int I2C_SDA_PIN = 20;
     constexpr int I2C_SCL_PIN = 21;
@@ -26,8 +26,8 @@ namespace CONFIG {
 
 
     enum DrivingDirection {
-        SteerableWheelsAtFront,
-        SteerableWheelsAtRear
+        CarSteering = 1,
+        ForkliftSteering = -1
     };
 
     // chassis geometry
@@ -63,26 +63,26 @@ namespace CONFIG {
 
     // Define WHEEL_DIAMETER and GEAR_RATIO based on CURRENT_CHALLENGE
     #if (CURRENT_CHALLENGE == ECO_DISASTER)
-        constexpr float WHEEL_DIAMETER = SMALL_WHEEL_DIAMETER; //LARGE_WHEEL_DIAMETER;
-        constexpr float GEAR_RATIO = GEARMOTOR_RATIO; //42.0 / 18.0 * GEARMOTOR_RATIO;
-        constexpr DrivingDirection DRIVING_DIRECTION = SteerableWheelsAtRear;
+        constexpr float WHEEL_DIAMETER = LARGE_WHEEL_DIAMETER;
+        constexpr float GEAR_RATIO = 42.0 / 18.0 * GEARMOTOR_RATIO;
+        constexpr DrivingDirection DRIVING_DIRECTION = ForkliftSteering;
     #elif (CURRENT_CHALLENGE == ESCAPE_ROUTE || CURRENT_CHALLENGE == MINESWEEPER || CURRENT_CHALLENGE == ZOMBIE_APOCALYPSE)
         const float WHEEL_DIAMETER = SMALL_WHEEL_DIAMETER;
         const float GEAR_RATIO = GEARMOTOR_RATIO;
-        constexpr DrivingDirection DRIVING_DIRECTION = SteerableWheelsAtFront;
+        constexpr DrivingDirection DRIVING_DIRECTION = CarSteering;
     #elif (CURRENT_CHALLENGE == PI_NOON)
         const float WHEEL_DIAMETER = MECANUM_DIAMETER;
         const float GEAR_RATIO = GEARMOTOR_RATIO;
-        constexpr DrivingDirection DRIVING_DIRECTION = SteerableWheelsAtFront;
+        constexpr DrivingDirection DRIVING_DIRECTION = CarSteering;
     #elif  (CURRENT_CHALLENGE == LAVA_PALAVA || CURRENT_CHALLENGE == TEMPLE_OF_DOOM)
         const float WHEEL_DIAMETER = LARGE_WHEEL_DIAMETER;
         const float GEAR_RATIO = GEARMOTOR_RATIO;
-        constexpr DrivingDirection DRIVING_DIRECTION = SteerableWheelsAtFront;
+        constexpr DrivingDirection DRIVING_DIRECTION = CarSteering;
     #else
         // Default case
         const float WHEEL_DIAMETER = SMALL_WHEEL_DIAMETER;
         const float GEAR_RATIO = GEARMOTOR_RATIO;
-        constexpr DrivingDirection DRIVING_DIRECTION = SteerableWheelsAtFront;
+        constexpr DrivingDirection DRIVING_DIRECTION = CarSteering;
     #endif
 
 

--- a/libs/config/include/drivetrain_config.h
+++ b/libs/config/include/drivetrain_config.h
@@ -13,7 +13,7 @@ namespace CONFIG {
     #define PI_NOON 5
     #define TEMPLE_OF_DOOM 6
 
-    #define CURRENT_CHALLENGE ESCAPE_ROUTE
+    #define CURRENT_CHALLENGE ECO_DISASTER
 
     constexpr int I2C_SDA_PIN = 20;
     constexpr int I2C_SCL_PIN = 21;
@@ -63,8 +63,8 @@ namespace CONFIG {
 
     // Define WHEEL_DIAMETER and GEAR_RATIO based on CURRENT_CHALLENGE
     #if (CURRENT_CHALLENGE == ECO_DISASTER)
-        constexpr float WHEEL_DIAMETER = LARGE_WHEEL_DIAMETER;
-        constexpr float GEAR_RATIO = 42.0 / 18.0 * GEARMOTOR_RATIO;
+        constexpr float WHEEL_DIAMETER = SMALL_WHEEL_DIAMETER; //LARGE_WHEEL_DIAMETER;
+        constexpr float GEAR_RATIO = GEARMOTOR_RATIO; //42.0 / 18.0 * GEARMOTOR_RATIO;
         constexpr DrivingDirection DRIVING_DIRECTION = SteerableWheelsAtRear;
     #elif (CURRENT_CHALLENGE == ESCAPE_ROUTE || CURRENT_CHALLENGE == MINESWEEPER || CURRENT_CHALLENGE == ZOMBIE_APOCALYPSE)
         const float WHEEL_DIAMETER = SMALL_WHEEL_DIAMETER;

--- a/libs/navigator/include/navigator.h
+++ b/libs/navigator/include/navigator.h
@@ -1,11 +1,13 @@
 #include "receiver.h"
 #include "statemanager.h"
+#include "drivetrain_config.h"
 
 class Navigator {
 public:
-    explicit Navigator(const Receiver* receiver, STATEMANAGER::StateManager *stateManager);
+    explicit Navigator(const Receiver* receiver, STATEMANAGER::StateManager *stateManager, CONFIG::DrivingDirection direction);
     ~Navigator();
     void navigate();
+    int driveDirectionFactor; //factor to change requested motor speed direction based on what we currently consider the front
 
 private:
     const Receiver *receiver{};

--- a/libs/navigator/include/navigator.h
+++ b/libs/navigator/include/navigator.h
@@ -7,7 +7,7 @@ public:
     explicit Navigator(const Receiver* receiver, STATEMANAGER::StateManager *stateManager, CONFIG::DrivingDirection direction);
     ~Navigator();
     void navigate();
-    int driveDirectionFactor; //factor to change requested motor speed direction based on what we currently consider the front
+    CONFIG::DrivingDirection driveDirectionFactor; //factor to change requested motor speed direction based on what we currently consider the front
 
 private:
     const Receiver *receiver{};

--- a/libs/navigator/include/navigator.h
+++ b/libs/navigator/include/navigator.h
@@ -4,10 +4,10 @@
 
 class Navigator {
 public:
-    explicit Navigator(const Receiver* receiver, STATEMANAGER::StateManager *stateManager, CONFIG::DrivingDirection direction);
+    explicit Navigator(const Receiver* receiver, STATEMANAGER::StateManager *stateManager, CONFIG::SteeringStyle direction);
     ~Navigator();
     void navigate();
-    CONFIG::DrivingDirection driveDirectionFactor; //factor to change requested motor speed direction based on what we currently consider the front
+    CONFIG::SteeringStyle driveDirection; //factor to change requested motor speed direction based on what we currently consider the front
 
 private:
     const Receiver *receiver{};

--- a/libs/navigator/src/navigator.cpp
+++ b/libs/navigator/src/navigator.cpp
@@ -2,13 +2,16 @@
 #include "navigator.h"
 #include "statemanager.h"
 #include "state_estimator.h"
-
 #include "drivetrain_config.h"
 
-Navigator::Navigator(const Receiver* receiver, STATEMANAGER::StateManager* stateManager) {
+Navigator::Navigator(const Receiver* receiver, STATEMANAGER::StateManager* stateManager, CONFIG::DrivingDirection direction) {
     this->receiver = receiver;
     this->pStateManager = stateManager;
-
+    if (direction == CONFIG::DrivingDirection::SteerableWheelsAtFront){
+        driveDirectionFactor = 1;
+    } else {
+        driveDirectionFactor = -1;
+    }
 }
 
 void Navigator::navigate() {
@@ -24,10 +27,11 @@ void Navigator::navigate() {
         //printf("NC: %f ", values.NC);
         //printf("\n");
 
+        printf("DriveDirectionFactor: %d\n", driveDirectionFactor);
         // send the receiver data to the state manager
         // TODO: use a queue to send the receiver data to the state manager
         STATE_ESTIMATOR::State requestedState{};
-        requestedState.velocity.velocity = values.ELE * CONFIG::MAX_VELOCITY;
+        requestedState.velocity.velocity = driveDirectionFactor * values.ELE * CONFIG::MAX_VELOCITY;
         requestedState.velocity.angular_velocity = values.AIL * CONFIG::MAX_ANGULAR_VELOCITY;
         pStateManager->requestState(requestedState);
     } else {

--- a/libs/navigator/src/navigator.cpp
+++ b/libs/navigator/src/navigator.cpp
@@ -7,11 +7,8 @@
 Navigator::Navigator(const Receiver* receiver, STATEMANAGER::StateManager* stateManager, CONFIG::DrivingDirection direction) {
     this->receiver = receiver;
     this->pStateManager = stateManager;
-    if (direction == CONFIG::DrivingDirection::SteerableWheelsAtFront){
-        driveDirectionFactor = 1;
-    } else {
-        driveDirectionFactor = -1;
-    }
+
+    driveDirectionFactor = direction;
 }
 
 void Navigator::navigate() {

--- a/libs/navigator/src/navigator.cpp
+++ b/libs/navigator/src/navigator.cpp
@@ -4,11 +4,11 @@
 #include "state_estimator.h"
 #include "drivetrain_config.h"
 
-Navigator::Navigator(const Receiver* receiver, STATEMANAGER::StateManager* stateManager, CONFIG::DrivingDirection direction) {
+Navigator::Navigator(const Receiver* receiver, STATEMANAGER::StateManager* stateManager, CONFIG::SteeringStyle direction) {
     this->receiver = receiver;
     this->pStateManager = stateManager;
 
-    driveDirectionFactor = direction;
+    driveDirection = direction;
 }
 
 void Navigator::navigate() {
@@ -27,7 +27,7 @@ void Navigator::navigate() {
         // send the receiver data to the state manager
         // TODO: use a queue to send the receiver data to the state manager
         STATE_ESTIMATOR::State requestedState{};
-        requestedState.velocity.velocity = driveDirectionFactor * values.ELE * CONFIG::MAX_VELOCITY;
+        requestedState.velocity.velocity = driveDirection * values.ELE * CONFIG::MAX_VELOCITY;
         requestedState.velocity.angular_velocity = values.AIL * CONFIG::MAX_ANGULAR_VELOCITY;
         pStateManager->requestState(requestedState);
     } else {

--- a/libs/navigator/src/navigator.cpp
+++ b/libs/navigator/src/navigator.cpp
@@ -27,7 +27,6 @@ void Navigator::navigate() {
         //printf("NC: %f ", values.NC);
         //printf("\n");
 
-        printf("DriveDirectionFactor: %d\n", driveDirectionFactor);
         // send the receiver data to the state manager
         // TODO: use a queue to send the receiver data to the state manager
         STATE_ESTIMATOR::State requestedState{};

--- a/libs/state_estimator/include/state_estimator.h
+++ b/libs/state_estimator/include/state_estimator.h
@@ -35,7 +35,7 @@ namespace STATE_ESTIMATOR {
 
     class StateEstimator : public Subject {
     public:
-        explicit StateEstimator(BNO08x* IMUinstance);
+        explicit StateEstimator(BNO08x* IMUinstance, CONFIG::DrivingDirection direction);
 
     protected:
         ~StateEstimator(); // Destructor to cancel the timer
@@ -56,6 +56,9 @@ namespace STATE_ESTIMATOR {
 
         void calculate_bilateral_speeds(const MotorSpeeds& motor_speeds, SteeringAngles steering_angles,
                                         float& left_speed, float& right_speed);
+
+        int driveDirectionFactor; //factor to change odometry direction based on what we currently consider the front
+
 
     private:
         Encoder* encoders[MOTOR_POSITION::MOTOR_POSITION_COUNT];

--- a/libs/state_estimator/include/state_estimator.h
+++ b/libs/state_estimator/include/state_estimator.h
@@ -57,7 +57,7 @@ namespace STATE_ESTIMATOR {
         void calculate_bilateral_speeds(const MotorSpeeds& motor_speeds, SteeringAngles steering_angles,
                                         float& left_speed, float& right_speed);
 
-        int driveDirectionFactor; //factor to change odometry direction based on what we currently consider the front
+        CONFIG::DrivingDirection driveDirection; //factor to change odometry direction based on what we currently consider the front
 
 
     private:

--- a/libs/state_estimator/include/state_estimator.h
+++ b/libs/state_estimator/include/state_estimator.h
@@ -35,7 +35,7 @@ namespace STATE_ESTIMATOR {
 
     class StateEstimator : public Subject {
     public:
-        explicit StateEstimator(BNO08x* IMUinstance, CONFIG::DrivingDirection direction);
+        explicit StateEstimator(BNO08x* IMUinstance, CONFIG::SteeringStyle direction);
 
     protected:
         ~StateEstimator(); // Destructor to cancel the timer
@@ -57,7 +57,7 @@ namespace STATE_ESTIMATOR {
         void calculate_bilateral_speeds(const MotorSpeeds& motor_speeds, SteeringAngles steering_angles,
                                         float& left_speed, float& right_speed);
 
-        CONFIG::DrivingDirection driveDirection; //factor to change odometry direction based on what we currently consider the front
+        CONFIG::SteeringStyle driveDirection; //factor to change odometry direction based on what we currently consider the front
 
 
     private:

--- a/libs/state_estimator/src/state_estimator.cpp
+++ b/libs/state_estimator/src/state_estimator.cpp
@@ -46,11 +46,9 @@ namespace STATE_ESTIMATOR {
                 sleep_ms(1000);
             }
         }
-        if (direction == CONFIG::DrivingDirection::SteerableWheelsAtFront){
-            driveDirectionFactor = 1;
-        } else {
-            driveDirectionFactor = -1;
-        }
+        
+        driveDirection = direction;
+        
         setupTimer();
     }
 
@@ -124,8 +122,8 @@ namespace STATE_ESTIMATOR {
 
     void StateEstimator::calculate_new_position(State& tmpState, const float distance_travelled, const float heading) {
         //use the latest heading and distance travleled to update the estiamted position
-        tmpState.odometry.x -= driveDirectionFactor * distance_travelled * sin(heading);
-        tmpState.odometry.y += driveDirectionFactor * distance_travelled * cos(heading);
+        tmpState.odometry.x -= driveDirection * distance_travelled * sin(heading);
+        tmpState.odometry.y += driveDirection * distance_travelled * cos(heading);
 
         //now actually update odometry's heading
         tmpState.odometry.heading = heading;
@@ -138,8 +136,8 @@ namespace STATE_ESTIMATOR {
         // TODO return a velocities struct instead of setting individual values
         Velocity tmpVelocity{};
         tmpVelocity.velocity = (left_speed - right_speed) / 2;
-        tmpVelocity.x_dot = -driveDirectionFactor * tmpVelocity.velocity * sin(new_heading);
-        tmpVelocity.y_dot = driveDirectionFactor * tmpVelocity.velocity * cos(new_heading);
+        tmpVelocity.x_dot = -driveDirection * tmpVelocity.velocity * sin(new_heading);
+        tmpVelocity.y_dot = driveDirection * tmpVelocity.velocity * cos(new_heading);
        
         tmpVelocity.angular_velocity = 1000 * (wrap_pi(new_heading - previous_heading)) / timerInterval;
         return tmpVelocity;

--- a/libs/state_estimator/src/state_estimator.cpp
+++ b/libs/state_estimator/src/state_estimator.cpp
@@ -10,7 +10,7 @@
 namespace STATE_ESTIMATOR {
     StateEstimator *StateEstimator::instancePtr = nullptr;
 
-    StateEstimator::StateEstimator(BNO08x* IMUinstance) : encoders{
+    StateEstimator::StateEstimator(BNO08x* IMUinstance, CONFIG::DrivingDirection direction) : encoders{
             [MOTOR_POSITION::FRONT_LEFT] =new Encoder(pio0, 0, motor2040::ENCODER_A, PIN_UNUSED, Direction::NORMAL_DIR, CONFIG::COUNTS_PER_REV),
             [MOTOR_POSITION::FRONT_RIGHT] =new Encoder(pio0, 1, motor2040::ENCODER_B, PIN_UNUSED, Direction::NORMAL_DIR, CONFIG::COUNTS_PER_REV),
             [MOTOR_POSITION::REAR_LEFT] = new Encoder(pio0, 2, motor2040::ENCODER_C, PIN_UNUSED, Direction::NORMAL_DIR, CONFIG::COUNTS_PER_REV),
@@ -45,6 +45,11 @@ namespace STATE_ESTIMATOR {
                 printf("failed to set initial heading offset\n");
                 sleep_ms(1000);
             }
+        }
+        if (direction == CONFIG::DrivingDirection::SteerableWheelsAtFront){
+            driveDirectionFactor = 1;
+        } else {
+            driveDirectionFactor = -1;
         }
         setupTimer();
     }
@@ -119,8 +124,8 @@ namespace STATE_ESTIMATOR {
 
     void StateEstimator::calculate_new_position(State& tmpState, const float distance_travelled, const float heading) {
         //use the latest heading and distance travleled to update the estiamted position
-        tmpState.odometry.x -= distance_travelled * sin(heading);
-        tmpState.odometry.y += distance_travelled * cos(heading);
+        tmpState.odometry.x -= driveDirectionFactor * distance_travelled * sin(heading);
+        tmpState.odometry.y += driveDirectionFactor * distance_travelled * cos(heading);
 
         //now actually update odometry's heading
         tmpState.odometry.heading = heading;
@@ -133,8 +138,8 @@ namespace STATE_ESTIMATOR {
         // TODO return a velocities struct instead of setting individual values
         Velocity tmpVelocity{};
         tmpVelocity.velocity = (left_speed - right_speed) / 2;
-        tmpVelocity.x_dot = tmpVelocity.velocity * sin(new_heading);
-        tmpVelocity.y_dot = tmpVelocity.velocity * cos(new_heading);
+        tmpVelocity.x_dot = -driveDirectionFactor * tmpVelocity.velocity * sin(new_heading);
+        tmpVelocity.y_dot = driveDirectionFactor * tmpVelocity.velocity * cos(new_heading);
        
         tmpVelocity.angular_velocity = 1000 * (wrap_pi(new_heading - previous_heading)) / timerInterval;
         return tmpVelocity;

--- a/libs/state_estimator/src/state_estimator.cpp
+++ b/libs/state_estimator/src/state_estimator.cpp
@@ -10,7 +10,7 @@
 namespace STATE_ESTIMATOR {
     StateEstimator *StateEstimator::instancePtr = nullptr;
 
-    StateEstimator::StateEstimator(BNO08x* IMUinstance, CONFIG::DrivingDirection direction) : encoders{
+    StateEstimator::StateEstimator(BNO08x* IMUinstance, CONFIG::SteeringStyle direction) : encoders{
             [MOTOR_POSITION::FRONT_LEFT] =new Encoder(pio0, 0, motor2040::ENCODER_A, PIN_UNUSED, Direction::NORMAL_DIR, CONFIG::COUNTS_PER_REV),
             [MOTOR_POSITION::FRONT_RIGHT] =new Encoder(pio0, 1, motor2040::ENCODER_B, PIN_UNUSED, Direction::NORMAL_DIR, CONFIG::COUNTS_PER_REV),
             [MOTOR_POSITION::REAR_LEFT] = new Encoder(pio0, 2, motor2040::ENCODER_C, PIN_UNUSED, Direction::NORMAL_DIR, CONFIG::COUNTS_PER_REV),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,7 +71,7 @@ int main() {
     IMU.enableRotationVector();
 
     // set up the state estimator
-    auto *pStateEstimator = new STATE_ESTIMATOR::StateEstimator(&IMU, CONFIG::DRIVING_DIRECTION);
+    auto *pStateEstimator = new STATE_ESTIMATOR::StateEstimator(&IMU, CONFIG::DRIVING_STYLE);
 
     // set up the state manager
     using namespace STATEMANAGER;
@@ -86,7 +86,7 @@ int main() {
     Receiver *pReceiver = getReceiver(motor::motor2040::RX_ECHO);
 
     // set up the navigator
-    navigator = new Navigator(pReceiver, pStateManager, CONFIG::DRIVING_DIRECTION);
+    navigator = new Navigator(pReceiver, pStateManager, CONFIG::DRIVING_STYLE);
 
     // Initialize a hardware timer
     repeating_timer_t navigationTimer;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,7 +52,7 @@ int main() {
     Receiver *pReceiver = getReceiver(motor::motor2040::RX_ECHO);
 
     // set up the navigator
-    navigator = new Navigator(pReceiver, pStateManager);
+    navigator = new Navigator(pReceiver, pStateManager, CONFIG::DRIVING_DIRECTION);
 
     // Initialize a hardware timer
     repeating_timer_t navigationTimer;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,7 +37,7 @@ int main() {
     IMU.enableRotationVector();
 
     // set up the state estimator
-    auto *pStateEstimator = new STATE_ESTIMATOR::StateEstimator(&IMU);
+    auto *pStateEstimator = new STATE_ESTIMATOR::StateEstimator(&IMU, CONFIG::DRIVING_DIRECTION);
 
     // set up the state manager
     using namespace STATEMANAGER;


### PR DESCRIPTION
This allows us to drive "backwards" (steereable wheels at the back) for the Ecodisaster challenge, without any other changes. 