### PR TITLE
Enable zeroing odometry (heading and X/Y) and assign them to transmitter channels

### DIFF
--- a/libs/common/include/interfaces.h
+++ b/libs/common/include/interfaces.h
@@ -14,7 +14,7 @@ namespace COMMON {
         ~Observer() = default;
 
     public:
-        virtual void update(DriveTrainState newState) = 0;
+        virtual void update(VehicleState newState) = 0;
     };
 
 
@@ -25,7 +25,7 @@ namespace COMMON {
 
     public:
         virtual void addObserver(Observer* observer) = 0;
-        virtual void notifyObservers(DriveTrainState newState) = 0;
+        virtual void notifyObservers(VehicleState newState) = 0;
     };
 
 } // COMMON

--- a/libs/common/include/types.h
+++ b/libs/common/include/types.h
@@ -49,6 +49,11 @@ namespace COMMON {
         float velocity;
         float angular_velocity;
     };
+    struct VehicleState {
+        Velocity velocity;
+        Odometry odometry;
+        DriveTrainState driveTrainState;
+    };
 }
 
 #endif //OSOD_MOTOR_2040_TYPES_H

--- a/libs/navigator/CMakeLists.txt
+++ b/libs/navigator/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(navigator STATIC
         src/navigator.cpp
 )
 target_link_libraries(navigator PUBLIC
+        common
         pico_cppm
         receiver
         statemanager

--- a/libs/navigator/include/navigator.h
+++ b/libs/navigator/include/navigator.h
@@ -1,15 +1,24 @@
 #include "receiver.h"
 #include "statemanager.h"
+#include "types.h"
+#include "interfaces.h"
 #include "drivetrain_config.h"
 
-class Navigator {
+using namespace COMMON;
+class Navigator: public Observer {
 public:
-    explicit Navigator(const Receiver* receiver, STATEMANAGER::StateManager *stateManager, CONFIG::SteeringStyle direction);
+    explicit Navigator(const Receiver* receiver, 
+                        STATEMANAGER::StateManager *stateManager,
+                        STATE_ESTIMATOR::StateEstimator* estimator,
+                        CONFIG::SteeringStyle direction);
     ~Navigator();
     void navigate();
     CONFIG::SteeringStyle driveDirection; //factor to change requested motor speed direction based on what we currently consider the front
+    void update(const DriveTrainState newState) override;
 
 private:
     const Receiver *receiver{};
     STATEMANAGER::StateManager *pStateManager;
+    STATE_ESTIMATOR::StateEstimator* pStateEstimator;
+    DriveTrainState current_state;
 };

--- a/libs/navigator/include/navigator.h
+++ b/libs/navigator/include/navigator.h
@@ -14,11 +14,11 @@ public:
     ~Navigator();
     void navigate();
     CONFIG::SteeringStyle driveDirection; //factor to change requested motor speed direction based on what we currently consider the front
-    void update(const DriveTrainState newState) override;
+    void update(const VehicleState newState) override;
 
 private:
     const Receiver *receiver{};
     STATEMANAGER::StateManager *pStateManager;
     STATE_ESTIMATOR::StateEstimator* pStateEstimator;
-    DriveTrainState current_state;
+    VehicleState current_state;
 };

--- a/libs/navigator/include/navigator.h
+++ b/libs/navigator/include/navigator.h
@@ -21,4 +21,11 @@ private:
     STATEMANAGER::StateManager *pStateManager;
     STATE_ESTIMATOR::StateEstimator* pStateEstimator;
     VehicleState current_state;
+    float setHeadingThreshold = -0.5; //if signal below this, set the heading
+    float setOriginThreshold = 0.5; //if signal above this, set the odometry origin
+    bool shouldSetHeading(float signal);
+    bool shouldSetOdometryOrigin(float signal);
+    void setHeading(); //local method that's linked to the stateEstimator set_Heading_Offset method
+    void setOrigin(); //local method that's linked to the stateEstimator set_Odometry_Offset method
+    void parseTxSignals(ReceiverChannelValues signals); //function to use "spare" transmitter channels as auxiliary inputs
 };

--- a/libs/navigator/include/navigator.h
+++ b/libs/navigator/include/navigator.h
@@ -27,5 +27,5 @@ private:
     bool shouldSetOdometryOrigin(float signal);
     void setHeading(); //local method that's linked to the stateEstimator set_Heading_Offset method
     void setOrigin(); //local method that's linked to the stateEstimator set_Odometry_Offset method
-    void parseTxSignals(ReceiverChannelValues signals); //function to use "spare" transmitter channels as auxiliary inputs
+    void parseTxSignals(const ReceiverChannelValues& signals); //function to use "spare" transmitter channels as auxiliary inputs
 };

--- a/libs/navigator/src/navigator.cpp
+++ b/libs/navigator/src/navigator.cpp
@@ -28,6 +28,9 @@ void Navigator::navigate() {
         //printf("NC: %f ", values.NC);
         //printf("\n");
 
+        //check if the extra Tx channels should trigger anything
+        parseTxSignals(values);
+
         // send the receiver data to the state manager
         // TODO: use a queue to send the receiver data to the state manager
         VehicleState requestedState{};
@@ -48,14 +51,11 @@ bool Navigator::shouldSetOdometryOrigin(float signal){
 }
 
 void Navigator::setHeading(){
-    //#TODO: add a timeout blocker to prevent this function being called twice in quick succession?
-    pStateEstimator->set_heading_offset();
+    pStateEstimator->zero_heading();
 }
 
 void Navigator::setOrigin(){
-    //As above: #TODO: add a timeout blocker to prevent this function being called twice in quick succession
-    // as that undos the original reset, if its called before the values have propogated through
-    pStateEstimator->apply_odometry_offset(current_state.odometry.x, current_state.odometry.y);
+    pStateEstimator->request_odometry_offset(current_state.odometry.x, current_state.odometry.y, 0);
 }
 
 void Navigator::update(const COMMON::VehicleState newState) {
@@ -68,14 +68,10 @@ void Navigator::parseTxSignals(ReceiverChannelValues signals){
         if (shouldSetHeading(signals.RUD)){
             printf("setting current heading to 0.\n");
             setHeading();
-            //a time delay seems to be needed after setting the heading to allow
-            //the signals to propogate through before this function can be called again.
-            sleep_ms(100);
         }
         if (shouldSetOdometryOrigin(signals.RUD)){
             printf("setting current position as zero for odometry.\n");
             setOrigin();
-            sleep_ms(100);
         }
 }
 

--- a/libs/navigator/src/navigator.cpp
+++ b/libs/navigator/src/navigator.cpp
@@ -30,7 +30,7 @@ void Navigator::navigate() {
 
         // send the receiver data to the state manager
         // TODO: use a queue to send the receiver data to the state manager
-        STATE_ESTIMATOR::State requestedState{};
+        VehicleState requestedState{};
         requestedState.velocity.velocity = driveDirection * values.ELE * CONFIG::MAX_VELOCITY;
         requestedState.velocity.angular_velocity = values.AIL * CONFIG::MAX_ANGULAR_VELOCITY;
         pStateManager->requestState(requestedState);
@@ -39,7 +39,8 @@ void Navigator::navigate() {
     }
 }
 
-void Navigator::update(const COMMON::DriveTrainState newState) {
+
+void Navigator::update(const COMMON::VehicleState newState) {
     current_state = newState;
 }
 

--- a/libs/navigator/src/navigator.cpp
+++ b/libs/navigator/src/navigator.cpp
@@ -39,9 +39,44 @@ void Navigator::navigate() {
     }
 }
 
+bool Navigator::shouldSetHeading(float signal){
+    return (signal < setHeadingThreshold);
+}
+
+bool Navigator::shouldSetOdometryOrigin(float signal){
+    return (signal > setOriginThreshold);
+}
+
+void Navigator::setHeading(){
+    //#TODO: add a timeout blocker to prevent this function being called twice in quick succession?
+    pStateEstimator->set_heading_offset();
+}
+
+void Navigator::setOrigin(){
+    //As above: #TODO: add a timeout blocker to prevent this function being called twice in quick succession
+    // as that undos the original reset, if its called before the values have propogated through
+    pStateEstimator->apply_odometry_offset(current_state.odometry.x, current_state.odometry.y);
+}
 
 void Navigator::update(const COMMON::VehicleState newState) {
     current_state = newState;
+}
+
+void Navigator::parseTxSignals(ReceiverChannelValues signals){
+    // function to use "spare" transmitter channels as auxiliary inputs
+    // currently can set (zero) odoemtry heading and and origin
+        if (shouldSetHeading(signals.RUD)){
+            printf("setting current heading to 0.\n");
+            setHeading();
+            //a time delay seems to be needed after setting the heading to allow
+            //the signals to propogate through before this function can be called again.
+            sleep_ms(100);
+        }
+        if (shouldSetOdometryOrigin(signals.RUD)){
+            printf("setting current position as zero for odometry.\n");
+            setOrigin();
+            sleep_ms(100);
+        }
 }
 
 Navigator::~Navigator() = default;

--- a/libs/navigator/src/navigator.cpp
+++ b/libs/navigator/src/navigator.cpp
@@ -62,7 +62,7 @@ void Navigator::update(const COMMON::VehicleState newState) {
     current_state = newState;
 }
 
-void Navigator::parseTxSignals(ReceiverChannelValues signals){
+void Navigator::parseTxSignals(const ReceiverChannelValues& signals){
     // function to use "spare" transmitter channels as auxiliary inputs
     // currently can set (zero) odoemtry heading and and origin
         if (shouldSetHeading(signals.RUD)){

--- a/libs/navigator/src/navigator.cpp
+++ b/libs/navigator/src/navigator.cpp
@@ -3,11 +3,15 @@
 #include "statemanager.h"
 #include "state_estimator.h"
 #include "drivetrain_config.h"
+#include "types.h"
 
-Navigator::Navigator(const Receiver* receiver, STATEMANAGER::StateManager* stateManager, CONFIG::SteeringStyle direction) {
+Navigator::Navigator(const Receiver* receiver,
+                     STATEMANAGER::StateManager* stateManager,
+                     STATE_ESTIMATOR::StateEstimator* stateEstimator,
+                     CONFIG::SteeringStyle direction) {
     this->receiver = receiver;
     this->pStateManager = stateManager;
-
+    this->pStateEstimator = stateEstimator;
     driveDirection = direction;
 }
 
@@ -33,6 +37,10 @@ void Navigator::navigate() {
     } else {
         printf("No receiver data available\n");
     }
+}
+
+void Navigator::update(const COMMON::DriveTrainState newState) {
+    current_state = newState;
 }
 
 Navigator::~Navigator() = default;

--- a/libs/state_estimator/include/state_estimator.h
+++ b/libs/state_estimator/include/state_estimator.h
@@ -54,16 +54,18 @@ namespace STATE_ESTIMATOR {
 
         CONFIG::SteeringStyle driveDirection; //factor to change odometry direction based on what we currently consider the front
 
-        void set_heading_offset(); 
+        void zero_heading(); 
 
-        void apply_odometry_offset(float xOffset, float yOffset);
+        void request_odometry_offset(float xOffset, float yOffset, float extraHeadingOffset);
+
+        Odometry odometryOffsetRequest;
 
     private:
         Encoder* encoders[MOTOR_POSITION::MOTOR_POSITION_COUNT];
         static StateEstimator* instancePtr;
         repeating_timer_t* timer;
         BNO08x* IMU;
-        float heading_offset;
+        float IMUHeadingOffset;
         //TODO: (related to issue #42) actually use timer (defined above) instead of fixed interval
         const uint32_t timerInterval = 50;  // Interval in milliseconds
         VehicleState estimatedState;
@@ -91,6 +93,7 @@ namespace STATE_ESTIMATOR {
         static MotorSpeeds get_wheel_speeds(const Encoder::Capture* encoderCaptures);
 
         [[nodiscard]] SteeringAngles estimate_steering_angles() const;
+        void process_odometry_offsets();
     };
 } // STATE_ESTIMATOR
 

--- a/libs/state_estimator/include/state_estimator.h
+++ b/libs/state_estimator/include/state_estimator.h
@@ -27,11 +27,6 @@ namespace STATE_ESTIMATOR {
     using namespace COMMON;
 
     // define a State struct containing the state parameters that can be requested or tracked
-    struct State {
-        Velocity velocity;
-        Odometry odometry;
-        DriveTrainState driveTrainState;
-    };
 
     class StateEstimator : public Subject {
     public:
@@ -48,7 +43,7 @@ namespace STATE_ESTIMATOR {
 
         void addObserver(Observer* observer) override;
 
-        void notifyObservers(DriveTrainState newState) override;
+        void notifyObservers(VehicleState newState) override;
 
         void updateCurrentSteeringAngles(const SteeringAngles& newSteeringAngles);
 
@@ -71,8 +66,8 @@ namespace STATE_ESTIMATOR {
         float heading_offset;
         //TODO: (related to issue #42) actually use timer (defined above) instead of fixed interval
         const uint32_t timerInterval = 50;  // Interval in milliseconds
-        State estimatedState;
-        State previousState;
+        VehicleState estimatedState;
+        VehicleState previousState;
         DriveTrainState currentDriveTrainState;
         SteeringAngles currentSteeringAngles;
 
@@ -89,7 +84,7 @@ namespace STATE_ESTIMATOR {
 
         void get_position_delta(Encoder::Capture encoderCaptures[4], float& distance_travelled) const;
 
-        void calculate_new_position(State& tmpState, float distance_travelled, float heading);
+        void calculate_new_position(VehicleState& tmpState, float distance_travelled, float heading);
 
         Velocity calculate_velocities(float new_heading, float previous_heading, float left_speed, float right_speed);
 

--- a/libs/state_estimator/include/state_estimator.h
+++ b/libs/state_estimator/include/state_estimator.h
@@ -59,6 +59,9 @@ namespace STATE_ESTIMATOR {
 
         CONFIG::SteeringStyle driveDirection; //factor to change odometry direction based on what we currently consider the front
 
+        void set_heading_offset(); 
+
+        void apply_odometry_offset(float xOffset, float yOffset);
 
     private:
         Encoder* encoders[MOTOR_POSITION::MOTOR_POSITION_COUNT];
@@ -83,8 +86,6 @@ namespace STATE_ESTIMATOR {
         void capture_encoders(Encoder::Capture* encoderCaptures) const;
         
         void get_latest_heading(float& heading);
-
-        bool initialise_heading_offset();
 
         void get_position_delta(Encoder::Capture encoderCaptures[4], float& distance_travelled) const;
 

--- a/libs/state_estimator/src/state_estimator.cpp
+++ b/libs/state_estimator/src/state_estimator.cpp
@@ -231,6 +231,7 @@ namespace STATE_ESTIMATOR {
 
     void StateEstimator::set_heading_offset() {
         // function sets the heading_offset to the current heading
+        //#TODO: add a timeout blocker to prevent this function being called twice in quick succession?
         heading_offset = wrap_pi(heading_offset + estimatedState.odometry.heading);
     }
 

--- a/libs/state_estimator/src/state_estimator.cpp
+++ b/libs/state_estimator/src/state_estimator.cpp
@@ -39,16 +39,11 @@ namespace STATE_ESTIMATOR {
         IMU = IMUinstance;
         
         instancePtr = this;
-
-        if (initialise_heading_offset() == false) {
-            while (1){
-                printf("failed to set initial heading offset\n");
-                sleep_ms(1000);
-            }
-        }
-        
+       
         driveDirection = direction;
         
+        set_heading_offset();
+
         setupTimer();
     }
 
@@ -234,25 +229,16 @@ namespace STATE_ESTIMATOR {
         currentSteeringAngles = newSteeringAngles;
     }
 
-    bool StateEstimator::initialise_heading_offset() {
+    void StateEstimator::set_heading_offset() {
         // function sets the heading_offset to the current heading
-        // returns true if the offset is set, false if timed out (no heading updates available)
-        long timeoutDuration = 5000;
-        long startTime = millis();
-        bool isUpdated = false; // Flag to indicate if heading_offset is updated
-
-        while (millis() - startTime < timeoutDuration && !isUpdated) {
-            if (IMU->getSensorEvent() == true) {
-                if (IMU->getSensorEventID() == SENSOR_REPORTID_ROTATION_VECTOR) {
-                    heading_offset = IMU->getYaw();
-                    isUpdated = true;
-                }
-            }
-        }
-        //if the timer expired before the heading was set, return false
-        return isUpdated;
+        heading_offset = wrap_pi(heading_offset + estimatedState.odometry.heading);
     }
 
+    void StateEstimator::apply_odometry_offset(float xOffset, float yOffset){
+        estimatedState.odometry.x = estimatedState.odometry.x - xOffset;
+        estimatedState.odometry.y = estimatedState.odometry.y - yOffset;
+    }
+    
     StateEstimator::~StateEstimator() {
         delete encoders[MOTOR_POSITION::FRONT_LEFT];
         delete encoders[MOTOR_POSITION::FRONT_RIGHT];

--- a/libs/state_estimator/src/state_estimator.cpp
+++ b/libs/state_estimator/src/state_estimator.cpp
@@ -71,7 +71,7 @@ namespace STATE_ESTIMATOR {
         }
     }
 
-    void StateEstimator::notifyObservers(const DriveTrainState newState) {
+    void StateEstimator::notifyObservers(const VehicleState newState) {
         for (int i = 0; i < observerCount; i++) {
             observers[i]->update(newState);
         }
@@ -115,7 +115,7 @@ namespace STATE_ESTIMATOR {
         distance_travelled = ((left_travel - right_travel) / 2) * CONFIG::WHEEL_DIAMETER / 2;
     }
 
-    void StateEstimator::calculate_new_position(State& tmpState, const float distance_travelled, const float heading) {
+    void StateEstimator::calculate_new_position(VehicleState& tmpState, const float distance_travelled, const float heading) {
         //use the latest heading and distance travleled to update the estiamted position
         tmpState.odometry.x -= driveDirection * distance_travelled * sin(heading);
         tmpState.odometry.y += driveDirection * distance_travelled * cos(heading);
@@ -152,7 +152,7 @@ namespace STATE_ESTIMATOR {
 
     void StateEstimator::estimateState() {
         // instantiate a copy of the current state
-        State tmpState = estimatedState;
+        VehicleState tmpState = estimatedState;
         
         //get current encoder state
         Encoder::Capture encoderCaptures[MOTOR_POSITION::MOTOR_POSITION_COUNT];
@@ -191,7 +191,7 @@ namespace STATE_ESTIMATOR {
         estimatedState = tmpState;
 
         // notify observers of the new state
-        notifyObservers(estimatedState.driveTrainState);
+        notifyObservers(estimatedState);
 
     }
 
@@ -238,7 +238,7 @@ namespace STATE_ESTIMATOR {
         estimatedState.odometry.x = estimatedState.odometry.x - xOffset;
         estimatedState.odometry.y = estimatedState.odometry.y - yOffset;
     }
-    
+
     StateEstimator::~StateEstimator() {
         delete encoders[MOTOR_POSITION::FRONT_LEFT];
         delete encoders[MOTOR_POSITION::FRONT_RIGHT];

--- a/libs/statemanager/include/statemanager.h
+++ b/libs/statemanager/include/statemanager.h
@@ -26,7 +26,7 @@ namespace STATEMANAGER {
 
         void initialiseServo(servo::Servo*& servo, uint pin, float minPulse, float midPulse, float maxPulse, float minValue, float midValue, float maxValue);
 
-        void requestState(const STATE_ESTIMATOR::State& requestedState);
+        void requestState(const COMMON::VehicleState& requestedState);
 
         void setServoSteeringAngle(const DriveTrainState& driveTrainState, CONFIG::Handedness side) const;
 

--- a/libs/statemanager/src/statemanager.cpp
+++ b/libs/statemanager/src/statemanager.cpp
@@ -34,7 +34,7 @@ namespace STATEMANAGER {
         initialiseServo(steering_servos.right, motor2040::TX_TRIG, 2000, 1400, 830);
     }
 
-    void StateManager::requestState(const STATE_ESTIMATOR::State& requestedState) {
+    void StateManager::requestState(const COMMON::VehicleState& requestedState) {
         //printf("Requested state...\n");
         //printf("Velocity: %f ", requestedState.velocity);
         //printf("Angular velocity: %f ", requestedState.angularVelocity);

--- a/libs/stoker/include/stoker.h
+++ b/libs/stoker/include/stoker.h
@@ -20,7 +20,7 @@ namespace STOKER {
         Stoker(const pin_pair &pins, MOTOR_POSITION::MotorPosition position, Direction direction);
         void set_speed(float speed);
 
-        void update(DriveTrainState newState) override;
+        void update(VehicleState newState) override;
 
     private:
         motor::Motor motor;

--- a/libs/stoker/src/stoker.cpp
+++ b/libs/stoker/src/stoker.cpp
@@ -15,8 +15,8 @@ namespace STOKER {
         motor.speed(speed + accel);
     }
 
-    void Stoker::update(const DriveTrainState newState) {
-        current_motor_speed = newState.speeds[motor_position_];
+    void Stoker::update(const VehicleState newState) {
+        current_motor_speed = newState.driveTrainState.speeds[motor_position_];
     }
 
 } // STOKER

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,7 +86,8 @@ int main() {
     Receiver *pReceiver = getReceiver(motor::motor2040::RX_ECHO);
 
     // set up the navigator
-    navigator = new Navigator(pReceiver, pStateManager, CONFIG::DRIVING_STYLE);
+    navigator = new Navigator(pReceiver, pStateManager, pStateEstimator, CONFIG::DRIVING_STYLE);
+    pStateEstimator->addObserver(navigator);
 
     // Initialize a hardware timer
     repeating_timer_t navigationTimer;


### PR DESCRIPTION
The methods work, but I've had to add a sleep to stop them double-triggering before the values have propogated through the system, and effectively reverting what's just been set.
They work as they are and the time delay isn't currently a problem since we're setting them manually whilst stationary.  
I've added some notes about this, I wonder if it'd be better to add a timed lock to the functions to prevent the double triggering (so that other functions aren't blocked if we use the methods in autonomous mode whilst driving), or if there's a better way to zero/apply offsets that doesn't suffer from the double-triggering problem?
Hopefully the potential double triggering failure mode is fairly clear. For setOrigin, I think it's because it uses Navigator's current_state property which takes some time to be updated, so if you call it twice in row before the values have propogated, you first set the origin to zero, then the second time you offset it again, effectively to minus the previous values. 