### PR TITLE
pass receiver values by const ref

### DIFF
--- a/libs/navigator/include/navigator.h
+++ b/libs/navigator/include/navigator.h
@@ -25,5 +25,5 @@ private:
     bool shouldSetOdometryOrigin(float signal);
     void setHeading(); //local method that's linked to the stateEstimator set_Heading_Offset method
     void setOrigin(); //local method that's linked to the stateEstimator set_Odometry_Offset method
-    void parseTxSignals(ReceiverChannelValues signals); //function to use "spare" transmitter channels as auxiliary inputs
+    void parseTxSignals(const ReceiverChannelValues& signals); //function to use "spare" transmitter channels as auxiliary inputs
 };

--- a/libs/navigator/src/navigator.cpp
+++ b/libs/navigator/src/navigator.cpp
@@ -60,7 +60,7 @@ void Navigator::update(const COMMON::VehicleState newState) {
     current_state = newState;
 }
 
-void Navigator::parseTxSignals(ReceiverChannelValues signals){
+void Navigator::parseTxSignals(const ReceiverChannelValues& signals){
     // function to use "spare" transmitter channels as auxiliary inputs
     // currently can set (zero) odoemtry heading and and origin
         if (shouldSetHeading(signals.RUD)){


### PR DESCRIPTION
Pass `signals` by const ref when calling `parseTXSignals`, to avoid memory allocation overhead