### PR TITLE
change bno08x detection failure into active loop

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,11 +63,9 @@ int main() {
    
     //set up IMU
     BNO08x IMU;
-    if (IMU.begin(CONFIG::BNO08X_ADDR, i2c_port0)==false) {
-        while (1){
-            printf("BNO08x not detected at default I2C address. Check wiring. Freezing\n");
-            sleep_ms(1000);
-        }
+    while (IMU.begin(CONFIG::BNO08X_ADDR, i2c_port0)==false) {
+        printf("BNO08x not detected at default I2C address. Check wiring. Freezing\n");
+        sleep_ms(1000);
     }
     IMU.enableRotationVector();
 


### PR DESCRIPTION
keep looking for the bno08x in the event that it isn't found, rather than entering an infinite loop.